### PR TITLE
Make interactive rebase behaviour consistent with magit

### DIFF
--- a/src/commands/rebasingCommands.ts
+++ b/src/commands/rebasingCommands.ts
@@ -107,7 +107,7 @@ async function rebaseInteractively({ repository, switches }: MenuState) {
   if (commit) {
     const interactiveSwitches = (switches ?? []).map(s => ({ ...s, activated: s.activated || s.longName === '--interactive' }));
 
-    const args = ['rebase', ...MenuUtil.switchesToArgs(interactiveSwitches), commit];
+    const args = ['rebase', ...MenuUtil.switchesToArgs(interactiveSwitches), `${commit}^`];
 
     return CommitCommands.runCommitLikeCommand(repository, args, { editor: 'GIT_SEQUENCE_EDITOR' });
   }


### PR DESCRIPTION
Hello! I just started using `vscode-magit` today and it's quite nice!

emacs magit assumes that a commit chosen for an interactive rebase is inclusive, like this (in this case I chose '9ed3566 removes 'code in path' suggestion`)

![Screenshot from 2020-05-13 16-37-35](https://user-images.githubusercontent.com/640347/81857122-27672600-9538-11ea-9596-6853b7e13020.png)

the command it emits ends up being `git rebase -i 9ed3566^`

By contrast, vscode magit currently uses the commit hash without the caret, resulting in a rebase that omits the selected commit, like this:

![Screenshot from 2020-05-13 16-40-57](https://user-images.githubusercontent.com/640347/81857388-947abb80-9538-11ea-83b3-f6259228333f.png)

This patch appends the caret to the commit chosen from the picker.