### PR TITLE
Use \t for clarity

### DIFF
--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -27,7 +27,7 @@ export class MenuUtil {
 
     return new Promise((resolve, reject) => {
 
-      let quickItems: MenuItem[] = menu.commands.map(item => ({ ...item, description: '	' + item.description }));
+      let quickItems: MenuItem[] = menu.commands.map(item => ({ ...item, description: `\t${item.description}` }));
 
       if (menuState.switches) {
 
@@ -35,7 +35,7 @@ export class MenuUtil {
         const activeSwitchesPresentation = `[ ${activeSwitches} ]`;
 
         quickItems.push({
-          label: '-', description: `	Switches ${activeSwitches.length > 0 ? activeSwitchesPresentation : ''}`, action: async (menuState: MenuState) => {
+          label: '-', description: `\tSwitches ${activeSwitches.length > 0 ? activeSwitchesPresentation : ''}`, action: async (menuState: MenuState) => {
 
             const updatedSwitches = await MenuUtil.showSwitchesMenu(menuState);
 
@@ -105,7 +105,7 @@ export class MenuUtil {
 
       _quickPick.ignoreFocusOut = true;
       if (menuState.switches) {
-        _quickPick.items = menuState.switches.map(s => ({ label: s.shortName, detail: s.longName, description: `  ${s.description}`, activated: s.activated }));
+        _quickPick.items = menuState.switches.map(s => ({ label: s.shortName, detail: s.longName, description: `\t${s.description}`, activated: s.activated }));
         _quickPick.selectedItems = _quickPick.items.filter(s => (s as any).activated);
         _quickPick.matchOnDescription = true;
         _quickPick.matchOnDetail = true;


### PR DESCRIPTION
This also fixes the L:108 at https://github.com/kahole/edamagit/commit/eae8a99e7be0c302180bcf43b2c1b77dc76698b4#diff-02f6072d6385688d8c57a196ebedcf23R108 where that tab was two space characters. Using `\t` will make this clearer.