### PR TITLE
Implement configurable help text (#24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,7 +362,9 @@
       "title": "Edamagit",
       "properties": {
         "edamagit.helpKeyConfig": {
-          "type": "object"
+          "type": "object",
+          "default": {},
+          "description": "Specifies the keys in the help text. This is useful when the default key bindings is changed."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -358,6 +358,14 @@
         "editor.lineHeight": 15
       }
     },
+    "configuration": {
+      "title": "Edamagit",
+      "properties": {
+        "edamagit.helpKeyConfig": {
+          "type": "object"
+        }
+      }
+    },
     "grammars": [
       {
         "language": "magit",

--- a/src/commands/helpCommands.ts
+++ b/src/commands/helpCommands.ts
@@ -1,12 +1,19 @@
 import { window, workspace } from 'vscode';
-import MagitUtils from '../utils/magitUtils';
-import { HelpView } from '../views/helpView';
+import { ConfigKey, ExtensionId } from '../common/constants';
+import { defaultHelpKeyConfig, HelpKeyConfig } from '../config/helpKeyConfig';
 import { views } from '../extension';
 import { MagitRepository } from '../models/magitRepository';
+import MagitUtils from '../utils/magitUtils';
+import { HelpView } from '../views/helpView';
+
+function getCoalescedConfig() {
+  const userConfig = workspace.getConfiguration(ExtensionId).get<HelpKeyConfig>(ConfigKey.HelpKeyConfig);
+  return { ...defaultHelpKeyConfig, ...userConfig };
+}
 
 export async function magitHelp(repository: MagitRepository) {
-
+  const config = getCoalescedConfig();
   const uri = HelpView.encodeLocation(repository);
-  views.set(uri.toString(), new HelpView(uri));
+  views.set(uri.toString(), new HelpView(uri, config));
   workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preserveFocus: true, preview: false }));
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -18,3 +18,8 @@ export const BranchDecoration = window.createTextEditorDecorationType({
 export const RemoteBranchDecoration = window.createTextEditorDecorationType({
   color: 'rgba(152,238,152,1.0)'
 });
+
+export const ExtensionId: string = 'edamagit';
+export const enum ConfigKey {
+  HelpKeyConfig = 'helpKeyConfig',
+}

--- a/src/config/helpKeyConfig.ts
+++ b/src/config/helpKeyConfig.ts
@@ -1,0 +1,66 @@
+export interface HelpKeyConfig {
+    // Popup and dwim commands
+    cherryPick: string;
+    branch: string;
+    commit: string;
+    diff: string;
+    fetch: string;
+    pull: string;
+    ignore: string;
+    log: string;
+    merge: string;
+    remote: string;
+    push: string;
+    rebase: string;
+    tag: string;
+    revert: string;
+    reset: string;
+    showRefs: string;
+    stash: string;
+    run: string;
+    worktree: string;
+    // Applying changes
+    apply: string;
+    stage: string;
+    stageAll: string;
+    unstage: string;
+    unstageAll: string;
+    reverse: string;
+    discard: string;
+    // Essential commands
+    refresh: string;
+    gitProcess: string;
+}
+
+export const defaultHelpKeyConfig: HelpKeyConfig = {
+    cherryPick: 'a',
+    branch: 'b',
+    commit: 'c',
+    diff: 'd',
+    fetch: 'f',
+    pull: 'F',
+    ignore: 'i',
+    log: 'l',
+    merge: 'm',
+    remote: 'M',
+    push: 'P',
+    rebase: 'r',
+    tag: 't',
+    revert: 'V',
+    reset: 'X',
+    showRefs: 'y',
+    stash: 'z',
+    run: '!',
+    worktree: '%',
+    // Applying changes
+    apply: 'a',
+    stage: 's',
+    stageAll: 'S',
+    unstage: 'u',
+    unstageAll: 'U',
+    reverse: 'v',
+    discard: 'k',
+    // Essential commands
+    refresh: 'g',
+    gitProcess: '$',
+};

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -1,4 +1,4 @@
-import { Uri } from 'vscode';
+import { Uri, TextEditorCursorStyle } from 'vscode';
 import * as Constants from '../common/constants';
 import { HelpKeyConfig } from '../config/helpKeyConfig';
 import { MagitRepository } from '../models/magitRepository';
@@ -6,25 +6,37 @@ import { MagitState } from '../models/magitState';
 import { DocumentView } from './general/documentView';
 import { TextView } from './general/textView';
 
+function joinTexts(spacing: number, texts: string[]) {
+  let joinedText = texts.length > 0 ? texts[0] : '';
+  for (let i = 1; i < texts.length; i++) {
+    const prev = texts[i - 1];
+    const current = texts[i];
+
+    const remainingSpacing = prev.length <= spacing ? spacing - prev.length : 0;
+    joinedText += ' '.repeat(remainingSpacing) + current;
+  }
+  return joinedText;
+}
+
 function createHelpText(c: HelpKeyConfig) {
   return `Popup and dwim commands
-  ${c.cherryPick} Cherry-pick       ${c.branch} Branch            ${c.commit} Commit
-  ${c.diff} Diff              ${c.fetch} Fetch             ${c.pull} Pull
-  ${c.ignore} Ignore            ${c.log} Log               ${c.merge} Merge
-  ${c.remote} Remote            ${c.push} Push              ${c.rebase} Rebase
-  ${c.tag} Tag               ${c.revert} Revert            ${c.reset} Reset
-  ${c.showRefs} Show Refs         ${c.stash} Stash             ${c.run} Run             ${c.worktree} Worktree
+  ${joinTexts(19, [`${c.cherryPick} Cherry-pick`, `${c.branch} Branch`, `${c.commit} Commit`])}
+  ${joinTexts(19, [`${c.diff} Diff`, `${c.fetch} Fetch`, `${c.pull} Pull`])}
+  ${joinTexts(19, [`${c.ignore} Ignore`, `${c.log} Log`, `${c.merge} Merge`])}
+  ${joinTexts(19, [`${c.remote} Remote`, `${c.push} Push`, `${c.rebase} Rebase`])}
+  ${joinTexts(19, [`${c.tag} Tag`, `${c.revert} Revert`, `${c.reset} Reset`])}
+  ${joinTexts(19, [`${c.showRefs} Show Refs`, `${c.stash} Stash`, `${c.run} Run`, `${c.worktree} Worktree`])}
 
 Applying changes
-  ${c.apply} Apply          ${c.stage} Stage          ${c.unstage} Unstage
-  ${c.reverse} Reverse        ${c.stageAll} Stage all      ${c.unstageAll} Unstage all
+  ${joinTexts(17, [`${c.apply} Apply`, `${c.stage} Stage`, `${c.unstage} Unstage`])}
+  ${joinTexts(17, [`${c.reverse} Reverse`, `${c.stageAll} Stage all`, `${c.unstageAll} Unstage all`])}
   ${c.discard} Discard
 
 Essential commands
- ${c.refresh}     refresh current buffer
- TAB   toggle section at point
- RET   visit thing at point
- ${c.gitProcess}     show git process view`;
+  ${joinTexts(6, [c.refresh, 'refresh current buffer'])}
+  ${joinTexts(6, ['TAB', 'toggle section at point'])}
+  ${joinTexts(6, ['RET', 'visit thing at point'])}
+  ${joinTexts(6, [c.gitProcess, 'show git process view'])}`;
 }
 
 export class HelpView extends DocumentView {
@@ -52,25 +64,6 @@ export class HelpView extends DocumentView {
   //   TAB   toggle section at point
   //   RET   visit thing at point
   //   C-h m show all key bindings`;
-
-  static HelpText: string = `Popup and dwim commands
-  A Cherry-pick       b Branch            c Commit
-  d Diff              f Fetch             F Pull
-  i Ignore            l Log               m Merge
-  M Remote            P Push              r Rebase
-  t Tag               V Revert            X Reset
-  y Show Refs         z Stash             ! Run             % Worktree
- 
-Applying changes
-  a Apply          s Stage          u Unstage
-  v Reverse        S Stage all      U Unstage all
-  k Discard
-  
-Essential commands
-  g     refresh current buffer
-  TAB   toggle section at point
-  RET   visit thing at point
-  $     show git process view`;
 
   constructor(uri: Uri, config: HelpKeyConfig) {
     super(uri);

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -1,9 +1,31 @@
-import { DocumentView } from './general/documentView';
 import { Uri } from 'vscode';
 import * as Constants from '../common/constants';
-import { TextView } from './general/textView';
+import { HelpKeyConfig } from '../config/helpKeyConfig';
 import { MagitRepository } from '../models/magitRepository';
 import { MagitState } from '../models/magitState';
+import { DocumentView } from './general/documentView';
+import { TextView } from './general/textView';
+
+function createHelpText(c: HelpKeyConfig) {
+  return `Popup and dwim commands
+  ${c.cherryPick} Cherry-pick       ${c.branch} Branch            ${c.commit} Commit
+  ${c.diff} Diff              ${c.fetch} Fetch             ${c.pull} Pull
+  ${c.ignore} Ignore            ${c.log} Log               ${c.merge} Merge
+  ${c.remote} Remote            ${c.push} Push              ${c.rebase} Rebase
+  ${c.tag} Tag               ${c.revert} Revert            ${c.reset} Reset
+  ${c.showRefs} Show Refs         ${c.stash} Stash             ${c.run} Run             ${c.worktree} Worktree
+
+Applying changes
+  ${c.apply} Apply          ${c.stage} Stage          ${c.unstage} Unstage
+  ${c.reverse} Reverse        ${c.stageAll} Stage all      ${c.unstageAll} Unstage all
+  ${c.discard} Discard
+
+Essential commands
+ ${c.refresh}     refresh current buffer
+ TAB   toggle section at point
+ RET   visit thing at point
+ ${c.gitProcess}     show git process view`;
+}
 
 export class HelpView extends DocumentView {
 
@@ -50,10 +72,10 @@ Essential commands
   RET   visit thing at point
   $     show git process view`;
 
-  constructor(uri: Uri) {
+  constructor(uri: Uri, config: HelpKeyConfig) {
     super(uri);
 
-    const diffTextView = new TextView(HelpView.HelpText);
+    const diffTextView = new TextView(createHelpText(config));
     diffTextView.isHighlightable = false;
     this.addSubview(diffTextView);
   }


### PR DESCRIPTION
I am taking a stab at this issue to add a configuration to the help text. Let me know how you feel about this. This implementation allows user to override key by key instead of override the whole config. For example:
```json
{
  "edamagit.helpKeyConfig": {
    "reverse": "x"
  }
}
```
A config like this will change the key of reverse in help text to `x` while keeping the default keys for the rest in the help text.