### PR TITLE
Log parsing issues for user key bindings

### DIFF
--- a/src/commands/helpCommands.ts
+++ b/src/commands/helpCommands.ts
@@ -11,14 +11,10 @@ export async function magitHelp(repository: MagitRepository) {
   let userKeyBindings = [];
 
   try {
-    userKeyBindings = await workspace.openTextDocument(keybindingsPath).then(document =>
-      JSON.parse(
-        document
-          .getText()
-          .replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '')
-      )
-    );
-  } catch { }
+    const userKeyBindingsDoc = await workspace.openTextDocument(keybindingsPath);
+    const userKeyBindingsText = userKeyBindingsDoc.getText().replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
+    userKeyBindings = JSON.parse(userKeyBindingsText);
+  } catch (e) { console.error(e); }
 
   const uri = HelpView.encodeLocation(repository);
   views.set(uri.toString(), new HelpView(uri, userKeyBindings));


### PR DESCRIPTION
Add logging so people can at least figure out what's wrong with their keybindings config. This happens to me because my `keybindings.json` has a trailing commas which vscode is able to read, but `JSON.parse` doesn't like that. This pull request is log the error so people can at least debug with the developer console.