### PR TITLE
Implements graph in logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1173,6 +1173,11 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
+		"date-fns": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
+			"integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw=="
+		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3111,9 +3116,9 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"mississippi": {
@@ -3156,12 +3161,12 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
 			}
 		},
 		"mocha": {

--- a/package.json
+++ b/package.json
@@ -598,5 +598,8 @@
     "vscode-test": "^1.3.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
+  },
+  "dependencies": {
+    "date-fns": "^2.14.0"
   }
 }

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -146,16 +146,49 @@ function parseLog(stdout: string) {
       const matches = l.matchAll(lineRe).next().value;
       if (matches && matches.length > 0) {
         const graph = matches[1]; // undefined if graph doesn't exist
-        commits.push(new MagitLogCommit({
+        const log = new LogCommit({
           graph: graph ? [graph] : undefined,
           hash: matches[2],
           refs: matches[4],
           author: matches[6],
           time: new Date(Number(matches[8]) * 1000), // convert seconds to milliseconds
           message: matches[9]
-        }));
+        });
+        commits.push(log);
       }
     }
   });
   return commits;
+}
+
+class LogCommit implements MagitLogCommit {
+  graph: string[] | undefined;
+  hash: string;
+  refs: string | undefined;
+  author: string;
+  time: Date;
+  message: string;
+
+  constructor(commit: {
+    graph: string[] | undefined;
+    hash: string;
+    refs: string | undefined;
+    author: string;
+    time: Date;
+    message: string;
+  }) {
+    this.graph = commit.graph;
+    this.hash = commit.hash;
+    this.refs = commit.refs;
+    this.author = commit.author;
+    this.time = commit.time;
+    this.message = commit.message;
+  }
+
+  get parents(): string[] {
+    throw Error('Not Implemented for LogCommit');
+  }
+  get authorEmail(): string | undefined {
+    throw Error('Not Implemented for LogCommit');
+  }
 }

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -11,7 +11,7 @@ import { create } from 'domain';
 const loggingMenu = {
   title: 'Logging',
   commands: [
-    { label: 'c', description: 'Log current', action: logHead },
+    { label: 'l', description: 'Log current', action: logHead },
     { label: 'h', description: 'Log HEAD', action: logHead },
   ]
 };

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -31,8 +31,8 @@ export async function logging(repository: MagitRepository) {
   return MenuUtil.showMenu(loggingMenu, { repository, switches });
 }
 
-// A function wrapping to avoid duplicate checking code
-function wrap(action: any) {
+// A function wrapper to avoid duplicate checking code
+function wrap(action: (repository: MagitRepository, head: MagitBranch, switches: Switch[]) => Thenable<void>) {
   return ({ repository, switches }: MenuState) => {
     if (repository.magitState?.HEAD && switches) {
       return action(repository, repository.magitState.HEAD, switches);

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -4,6 +4,8 @@ import { window, workspace } from 'vscode';
 import LogView from '../views/logView';
 import { views } from '../extension';
 import MagitUtils from '../utils/magitUtils';
+import { gitRun } from '../utils/gitRawRunner';
+import { Commit } from '../typings/git';
 
 const loggingMenu = {
   title: 'Logging',
@@ -21,11 +23,85 @@ async function logHead({ repository }: MenuState) {
 
   if (repository.magitState?.HEAD) {
 
-    const log = await repository.log({ maxEntries: 100 });
+    // const log = await repository.log({ maxEntries: 100 });
+    const output = await gitRun(repository, ['log', '--format=%H%d [%an] [%at]%s', '--graph', '-n100']);
+    const log = parseLog(output.stdout);
 
     const uri = LogView.encodeLocation(repository);
     views.set(uri.toString(), new LogView(uri, { commits: log, refName: repository.magitState?.HEAD.name! }));
     workspace.openTextDocument(uri)
       .then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preserveFocus: true, preview: false }));
+  }
+}
+
+function parseLog(stdout: string) {
+  const commits: LogCommit[] = [];
+  // http://www.unicode.org/reports/tr18/#Line_Boundaries
+  // const lines = stdout.split(/(?:\u{D A}|(?!\u{D A})[\u{A}-\u{D}\u{85}\u{2028}\u{2029}]/);
+  const lines = stdout.match(/[^\r\n]+/g);//.split(/\r?\n/);
+  const lineRe = new RegExp(
+    '([/|\\-_* .o]+)' + // Graph
+    '([a-f0-9]{40})' + // Sha
+    '( \\(([^()]+)\\))?' + // Refs
+    '( \\[([^\\[\\]]+)\\])' + // Author
+    '( \\[([^\\[\\]]+)\\])' + // Time
+    '(.*)', // Message
+    'g');
+  lines?.forEach(l => {
+    if (l.match(/^[/|\\-_* .o]+$/g)) { //graph only
+      // Add to previous commits
+      if (commits.length > 0) {
+        commits[commits.length - 1].graph.push(l);
+      }
+    } else {
+      // ES 2020 string to match all
+      // Convert to iterator to array with spread
+      const t = [...l.matchAll(lineRe)];
+      if (t && t.length > 0) {
+        commits.push(new LogCommit({
+          graph: [t[0][1]],
+          hash: t[0][2],
+          refs: t[0][4],
+          author: t[0][6],
+          time: new Date(Number(t[0][8]) * 1000),
+          message: t[0][9]
+        }));
+      }
+      console.log(t);
+    }
+  });
+  return commits;
+}
+interface ILogCommit {
+  graph: string[]
+  hash: string;
+  refs: string | undefined;
+  author: string;
+  time: Date;
+  message: string;
+}
+
+export class LogCommit implements Commit, ILogCommit {
+  graph: string[]
+  hash: string;
+  refs: string | undefined;
+  author: string;
+  time: Date;
+  message: string;
+
+  constructor(commit: ILogCommit) {
+    this.graph = commit.graph;
+    this.hash = commit.hash;
+    this.refs = commit.refs;
+    this.author = commit.author;
+    this.time = commit.time;
+    this.message = commit.message;
+  }
+
+  get parents(): string[] {
+    throw Error('Not Implement for LogCommit');
+  }
+  get authorEmail(): string | undefined {
+    return undefined;
   }
 }

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -103,6 +103,7 @@ async function getRevs(repository: MagitRepository) {
 
   window.setStatusBarMessage('Nothing selected', StatusMessageDisplayTimeout);
 }
+
 function createLogArgs(switches: Switch[]) {
   const switchMap = switches.reduce((prev, current) => {
     prev[current.shortName] = current;
@@ -111,7 +112,7 @@ function createLogArgs(switches: Switch[]) {
 
   const decorateFormat = switchMap['-d'].activated ? '%d' : '';
   const formatArg = `--format=%H${decorateFormat} [%an] [%at]%s`;
-  const args = ['log', formatArg, '-n100'];
+  const args = ['log', formatArg, '-n100', '--use-mailmap'];
   if (switchMap['-D'].activated) {
     args.push(switchMap['-D'].longName);
   }

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -120,7 +120,7 @@ async function log(repository: MagitRepository, args: string[], revs: string[]) 
 
 async function getRevs(repository: MagitRepository) {
   // TODO: Auto complete branches and tags
-  const input = await window.showInputBox({ prompt: 'Log rev,s:' });
+  const input = await window.showInputBox({ prompt: 'Log rev,s:', placeHolder: repository.magitState?.HEAD?.name });
   if (input && input.length > 0) {
     // split space or commas
     return input.split(/[, ]/g).filter(r => r.length > 0);

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -120,10 +120,14 @@ async function log(repository: MagitRepository, args: string[], revs: string[]) 
 
 async function getRevs(repository: MagitRepository) {
   // TODO: Auto complete branches and tags
-  const input = await window.showInputBox({ prompt: 'Log rev,s:', placeHolder: repository.magitState?.HEAD?.name });
+  const placeHolder = repository.magitState?.HEAD?.name;
+  const input = await window.showInputBox({ prompt: 'Log rev,s:', placeHolder });
   if (input && input.length > 0) {
     // split space or commas
     return input.split(/[, ]/g).filter(r => r.length > 0);
+  } else if (placeHolder) {
+    // if user didn't enter anything, but placeholder exist
+    return [placeHolder];
   }
 
   window.setStatusBarMessage('Nothing selected', StatusMessageDisplayTimeout);

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -17,6 +17,7 @@ const loggingMenu = {
 };
 
 const switches: Switch[] = [
+  { shortName: '-D', longName: '--simplify-by-decoration', description: 'Simplify by decoration' },
   { shortName: '-g', longName: '--graph', description: 'Show graph', activated: true },
   { shortName: '-d', longName: '--decorate', description: 'Show refnames', activated: true }
 ];
@@ -49,6 +50,9 @@ function createLogArgs(switches: Switch[]) {
   const decorateFormat = switchMap['-d'].activated ? '%d' : '';
   const formatArg = `--format=%H${decorateFormat} [%an] [%at]%s`;
   const args = ['log', formatArg, '-n100'];
+  if (switchMap['-D'].activated) {
+    args.push(switchMap['-D'].longName);
+  }
   if (switchMap['-g'].activated) {
     args.push(switchMap['-g'].longName);
   }

--- a/src/common/gitApiExtensions.ts
+++ b/src/common/gitApiExtensions.ts
@@ -3,7 +3,7 @@ import * as cp from 'child_process';
 
 // This refers to Repository in
 // vscode/extension/git/src/git.ts
-interface GitRepository {
+interface BaseGitRepository {
   run?(args: string[], options?: SpawnOptions): Promise<IExecutionResult<string>>;
   // run might become exec, included for future-proofing:
   exec?(args: string[], options?: SpawnOptions): Promise<IExecutionResult<string>>;
@@ -15,7 +15,7 @@ interface BaseRepository {
   getStashes(): Promise<Stash[]>;
   add(resources: Uri[], opts?: { update?: boolean }): Promise<void>;
   reset(treeish: string, hard?: boolean): Promise<void>;
-  repository: GitRepository;
+  repository: BaseGitRepository;
 }
 
 // This refers to ApiRepository from

--- a/src/common/gitApiExtensions.ts
+++ b/src/common/gitApiExtensions.ts
@@ -1,19 +1,25 @@
 import { Uri } from 'vscode';
 import * as cp from 'child_process';
 
-interface BaseBaseRepository {
+// This refers to Repository in
+// vscode/extension/git/src/git.ts
+interface GitRepository {
   run?(args: string[], options?: SpawnOptions): Promise<IExecutionResult<string>>;
   // run might become exec, included for future-proofing:
   exec?(args: string[], options?: SpawnOptions): Promise<IExecutionResult<string>>;
 }
 
+// This refers to the Repository in
+// vscode/extension/git/src/repository.ts
 interface BaseRepository {
   getStashes(): Promise<Stash[]>;
   add(resources: Uri[], opts?: { update?: boolean }): Promise<void>;
   reset(treeish: string, hard?: boolean): Promise<void>;
-  repository: BaseBaseRepository;
+  repository: GitRepository;
 }
 
+// This refers to ApiRepository from
+// vscode/extension/git/src/api/api1.ts
 declare module '../typings/git' {
   export interface Repository {
     readonly _repository: BaseRepository;

--- a/src/models/magitLog.ts
+++ b/src/models/magitLog.ts
@@ -1,6 +1,6 @@
-import { LogCommit } from '../commands/loggingCommands';
+import { MagitLogCommit } from './magitLogCommit';
 
 export interface MagitLog {
-  commits: LogCommit[];
+  commits: MagitLogCommit[];
   revName: string;
 }

--- a/src/models/magitLog.ts
+++ b/src/models/magitLog.ts
@@ -1,6 +1,7 @@
 import { Commit } from '../typings/git';
+import { LogCommit } from '../commands/loggingCommands';
 
 export interface MagitLog {
-  commits: Commit[];
+  commits: LogCommit[];
   refName: string;
 }

--- a/src/models/magitLog.ts
+++ b/src/models/magitLog.ts
@@ -1,7 +1,6 @@
-import { Commit } from '../typings/git';
 import { LogCommit } from '../commands/loggingCommands';
 
 export interface MagitLog {
   commits: LogCommit[];
-  refName: string;
+  revName: string;
 }

--- a/src/models/magitLogCommit.ts
+++ b/src/models/magitLogCommit.ts
@@ -1,35 +1,11 @@
 import { Commit } from '../typings/git';
 
-interface IMagitLogCommit {
+
+export interface MagitLogCommit extends Commit {
   graph: string[] | undefined;
   hash: string;
   refs: string | undefined;
   author: string;
   time: Date;
   message: string;
-}
-
-export class MagitLogCommit implements Commit, IMagitLogCommit {
-  graph: string[] | undefined;
-  hash: string;
-  refs: string | undefined;
-  author: string;
-  time: Date;
-  message: string;
-
-  constructor(commit: IMagitLogCommit) {
-    this.graph = commit.graph;
-    this.hash = commit.hash;
-    this.refs = commit.refs;
-    this.author = commit.author;
-    this.time = commit.time;
-    this.message = commit.message;
-  }
-
-  get parents(): string[] {
-    throw Error('Not Implemented for LogCommit');
-  }
-  get authorEmail(): string | undefined {
-    throw Error('Not Implemented for LogCommit');
-  }
 }

--- a/src/models/magitLogCommit.ts
+++ b/src/models/magitLogCommit.ts
@@ -1,0 +1,35 @@
+import { Commit } from '../typings/git';
+
+interface IMagitLogCommit {
+  graph: string[] | undefined;
+  hash: string;
+  refs: string | undefined;
+  author: string;
+  time: Date;
+  message: string;
+}
+
+export class MagitLogCommit implements Commit, IMagitLogCommit {
+  graph: string[] | undefined;
+  hash: string;
+  refs: string | undefined;
+  author: string;
+  time: Date;
+  message: string;
+
+  constructor(commit: IMagitLogCommit) {
+    this.graph = commit.graph;
+    this.hash = commit.hash;
+    this.refs = commit.refs;
+    this.author = commit.author;
+    this.time = commit.time;
+    this.message = commit.message;
+  }
+
+  get parents(): string[] {
+    throw Error('Not Implemented for LogCommit');
+  }
+  get authorEmail(): string | undefined {
+    throw Error('Not Implemented for LogCommit');
+  }
+}

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -8,6 +8,7 @@ import { MagitLog } from '../models/magitLog';
 import { Commit } from '../typings/git';
 import GitTextUtils from '../utils/gitTextUtils';
 import { MagitState } from '../models/magitState';
+import { LogCommit } from '../commands/loggingCommands';
 
 export default class LogView extends DocumentView {
 
@@ -32,8 +33,12 @@ export default class LogView extends DocumentView {
 
 export class CommitLongFormItemView extends CommitItemView {
 
-  constructor(public commit: Commit, qualifier?: string) {
+  constructor(public commit: LogCommit) {
     super(commit);
-    this.textContent = `${GitTextUtils.shortHash(commit.hash)} * ${GitTextUtils.shortCommitMessage(commit.message)}`.substr(0, 65).padEnd(70) + `${commit.authorEmail}`;
+    this.textContent = `${GitTextUtils.shortHash(commit.hash)} ${commit.graph[0]}${GitTextUtils.shortCommitMessage(commit.message)}`.substr(0, 65).padEnd(70) + `${commit.author}`;
+      for(let i = 1; i < commit.graph.length; i++) {
+        const emptyHashSpace = ' '.repeat(8);
+        this.textContent += `\n${emptyHashSpace}${commit.graph[i]}`;
+      }
   }
 }

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -9,6 +9,7 @@ import { Commit } from '../typings/git';
 import GitTextUtils from '../utils/gitTextUtils';
 import { MagitState } from '../models/magitState';
 import { LogCommit } from '../commands/loggingCommands';
+import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict';
 
 export default class LogView extends DocumentView {
 
@@ -35,10 +36,19 @@ export class CommitLongFormItemView extends CommitItemView {
 
   constructor(public commit: LogCommit) {
     super(commit);
-    this.textContent = `${GitTextUtils.shortHash(commit.hash)} ${commit.graph[0]}${GitTextUtils.shortCommitMessage(commit.message)}`.substr(0, 65).padEnd(70) + `${commit.author}`;
-      for(let i = 1; i < commit.graph.length; i++) {
-        const emptyHashSpace = ' '.repeat(8);
-        this.textContent += `\n${emptyHashSpace}${commit.graph[i]}`;
-      }
+    const timeDistance = formatDistanceToNowStrict(commit.time);
+    this.textContent = truncateText(`${GitTextUtils.shortHash(commit.hash)} ${commit.graph[0]}${GitTextUtils.shortCommitMessage(commit.message)}`, 65, 70) + `${truncateText(commit.author, 15, 20)}${timeDistance}`;
+    for (let i = 1; i < commit.graph.length; i++) {
+      const emptyHashSpace = ' '.repeat(8);
+      this.textContent += `\n${emptyHashSpace}${commit.graph[i]}`;
+    }
   }
+}
+
+function truncateText(txt: string, limit: number, padEnd?: number) {
+  let ret = (txt.length >= limit) ? txt.substr(0, limit - 1) + '…' : txt;
+  if (padEnd) {
+    ret = ret.padEnd(padEnd);
+  }
+  return ret;
 }

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -19,7 +19,7 @@ export default class LogView extends DocumentView {
     super(uri);
 
     this.subViews = [
-      new TextView(`Commits in ${log.refName}`),
+      new TextView(`Commits in ${log.revName}`),
       ...log.commits.map(commit => new CommitLongFormItemView(commit)),
     ];
   }

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -37,10 +37,19 @@ export class CommitLongFormItemView extends CommitItemView {
   constructor(public commit: LogCommit) {
     super(commit);
     const timeDistance = formatDistanceToNowStrict(commit.time);
-    this.textContent = truncateText(`${GitTextUtils.shortHash(commit.hash)} ${commit.graph[0]}${GitTextUtils.shortCommitMessage(commit.message)}`, 65, 70) + `${truncateText(commit.author, 15, 20)}${timeDistance}`;
-    for (let i = 1; i < commit.graph.length; i++) {
-      const emptyHashSpace = ' '.repeat(8);
-      this.textContent += `\n${emptyHashSpace}${commit.graph[i]}`;
+    const hash = `${GitTextUtils.shortHash(commit.hash)} `;
+    const graph = commit.graph?.[0] ?? '';
+    const refs = commit.refs ? `(${commit.refs}) ` : '';
+    const msg = GitTextUtils.shortCommitMessage(commit.message);
+    this.textContent = truncateText(`${hash}${graph}${refs}${msg}`, 65, 70) + `${truncateText(commit.author, 15, 20)}${timeDistance}`;
+
+    // Add the rest of the graph for this commit
+    if (commit.graph) {
+      for (let i = 1; i < commit.graph.length; i++) {
+        const g = commit.graph[i];
+        const emptyHashSpace = ' '.repeat(8);
+        this.textContent += `\n${emptyHashSpace}${g}`;
+      }
     }
   }
 }

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -41,7 +41,9 @@ export class CommitLongFormItemView extends CommitItemView {
     const graph = commit.graph?.[0] ?? '';
     const refs = commit.refs ? `(${commit.refs}) ` : '';
     const msg = GitTextUtils.shortCommitMessage(commit.message);
-    this.textContent = truncateText(`${hash}${graph}${refs}${msg}`, 65, 70) + `${truncateText(commit.author, 15, 20)}${timeDistance}`;
+    this.textContent = truncateText(`${hash}${graph}${refs}${msg}`, 69, 70) +
+      truncateText(commit.author, 17, 18) +
+      timeDistance;
 
     // Add the rest of the graph for this commit
     if (commit.graph) {

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -1,15 +1,14 @@
-import * as Constants from '../common/constants';
-import { DocumentView } from './general/documentView';
-import { Uri } from 'vscode';
-import { MagitRepository } from '../models/magitRepository';
-import { TextView } from './general/textView';
-import { CommitItemView } from './commits/commitSectionView';
-import { MagitLog } from '../models/magitLog';
-import { Commit } from '../typings/git';
-import GitTextUtils from '../utils/gitTextUtils';
-import { MagitState } from '../models/magitState';
-import { LogCommit } from '../commands/loggingCommands';
 import formatDistanceToNowStrict from 'date-fns/formatDistanceToNowStrict';
+import { Uri } from 'vscode';
+import * as Constants from '../common/constants';
+import { MagitLog } from '../models/magitLog';
+import { MagitLogCommit } from '../models/magitLogCommit';
+import { MagitRepository } from '../models/magitRepository';
+import { MagitState } from '../models/magitState';
+import GitTextUtils from '../utils/gitTextUtils';
+import { CommitItemView } from './commits/commitSectionView';
+import { DocumentView } from './general/documentView';
+import { TextView } from './general/textView';
 
 export default class LogView extends DocumentView {
 
@@ -34,7 +33,7 @@ export default class LogView extends DocumentView {
 
 export class CommitLongFormItemView extends CommitItemView {
 
-  constructor(public commit: LogCommit) {
+  constructor(public commit: MagitLogCommit) {
     super(commit);
     const timeDistance = formatDistanceToNowStrict(commit.time);
     const hash = `${GitTextUtils.shortHash(commit.hash)} `;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "es6",
     "outDir": "out",
     "lib": [
-      "es6"
+      "es6",
+      "ES2020.String"
     ],
     "sourceMap": true,
     "rootDir": "",


### PR DESCRIPTION
Fixes #38 

This PR implements the graph output in logging by executing raw git log commands directly to get the graph output like magit. That allows us to implement many switches that isn't possible with the git api provided by vscode.

## Implemented:
- [x] Show graph in log output with a switch (`-g`)
- [x] Show Author name in log
- [x] Show human readable timestamp on log with date-fn (tree-shaking by webpack should include only that function -- no bloat bundle)
- [x] Implement all log options. `l` for current, `o` for other, `h` for `HEAD`, `L` for all local branches, `b` for all branches, and `a` for all references
- [x] Implement switches for graph(`-g`), decoration (`-d`), and simplify by decoration(`-D)
- [x] Implement rev input box for  current (`l`) option with detached HEAD
- [x] Implement rev input box for other (`o`) option with default placeholder
- [x] Rev input box allows to log multiple rev separated by `,` or ` `

## Inconsistencies/Features still missing in logging:
- [ ] Decoration for log is not as concise as magit. (This requires more input parsing for decoration)
- [ ] rev input box do not have autocomplete like in magit. (This can potentially implemented with a QuickPick)
- [ ] Color graph (Need to use `--color`, and needs more input parsing, and a way to display color in a text doc)
- [ ] Any switches that requires a follow up input box like `-n` or `-F` (This requires more refactoring work with the switch code structure. This refactoring should allow multiple types of follow up input box)
- [ ] Reverse (This will be mutually exclusive with `--graph`)
- [ ] Reflog
- [ ] Signatures
- [ ] Header
- [ ] Patch
- [ ] Stat

This PR by itself should be ready, I am only listing the missing feature here just to track what else is needed to be done for logging to be feature complete