### PR TITLE
Initial, simplified version of magit-display-buffer-function

### DIFF
--- a/package.json
+++ b/package.json
@@ -359,6 +359,17 @@
         "editor.minimap.enabled": false
       }
     },
+    "configuration": {
+      "title": "Magit",
+      "properties": {
+        "magit.display-buffer-function": {
+          "type": "string",
+          "enum": ["other-column", "same-column"],
+          "default": "other-column",
+          "description": "Choose where new buffers will be displayed."
+        }
+      }
+    },
     "grammars": [
       {
         "language": "magit",

--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -118,7 +118,7 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
       for (const visibleEditor of window.visibleTextEditors) {
         if (visibleEditor.document.uri === stagedEditor.document.uri) {
           // This is a bit of a hack. Too bad about editor.hide() and editor.show() being deprecated.
-          const stagedEditorViewColumn = MagitUtils.oppositeActiveViewColumn();
+          const stagedEditorViewColumn = MagitUtils.showDocumentColumn();
           await window.showTextDocument(stagedEditor.document, { viewColumn: stagedEditorViewColumn, preview: false });
           await commands.executeCommand('workbench.action.closeActiveEditor');
           commands.executeCommand(`workbench.action.navigate${stagedEditorViewColumn === ViewColumn.One ? 'Right' : 'Left'}`);

--- a/src/commands/diffingCommands.ts
+++ b/src/commands/diffingCommands.ts
@@ -81,14 +81,14 @@ async function diff(repository: MagitRepository, id: string, args: string[] = []
 
   const uri = DiffView.encodeLocation(repository, id);
   views.set(uri.toString(), new DiffView(uri, diffResult.stdout));
-  return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preview: false }));
+  return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preview: false }));
 }
 
 export async function showDiffSection(repository: MagitRepository, section: Section, preserveFocus = false) {
   const uri = SectionDiffView.encodeLocation(repository);
   views.set(uri.toString(), new SectionDiffView(uri, repository.magitState!, section));
   return workspace.openTextDocument(uri)
-    .then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preserveFocus, preview: false }));
+    .then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preserveFocus, preview: false }));
 }
 
 async function showStash({ repository }: MenuState) {
@@ -109,7 +109,7 @@ export async function showStashDetail(repository: MagitRepository, stash: Stash)
   const stashDiff = result.stdout;
 
   views.set(uri.toString(), new StashDetailView(uri, stash, stashDiff));
-  return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preview: false }));
+  return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preview: false }));
 }
 
 async function showCommit({ repository }: MenuState) {

--- a/src/commands/helpCommands.ts
+++ b/src/commands/helpCommands.ts
@@ -18,5 +18,5 @@ export async function magitHelp(repository: MagitRepository) {
 
   const uri = HelpView.encodeLocation(repository);
   views.set(uri.toString(), new HelpView(uri, userKeyBindings));
-  workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preserveFocus: true, preview: false }));
+  workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preserveFocus: true, preview: false }));
 }

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -86,7 +86,7 @@ async function log(repository: MagitRepository, args: string[], revs: string[]) 
   const uri = LogView.encodeLocation(repository);
   views.set(uri.toString(), new LogView(uri, { entries: logEntries, revName }));
   workspace.openTextDocument(uri)
-    .then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preserveFocus: false, preview: false }));
+    .then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preserveFocus: false, preview: false }));
 }
 
 async function getRevs(repository: MagitRepository) {

--- a/src/commands/processCommands.ts
+++ b/src/commands/processCommands.ts
@@ -15,5 +15,5 @@ export async function processView(repository: MagitRepository) {
     views.set(uri.toString(), new ProcessView(uri));
   }
 
-  return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preview: false }));
+  return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preview: false }));
 }

--- a/src/commands/statusCommands.ts
+++ b/src/commands/statusCommands.ts
@@ -33,7 +33,7 @@ export async function magitStatus(editor: TextEditor, preserveFocus = false): Pr
         if (editor.document.uri.path === MagitStatusView.UriPath) {
           return;
         }
-        return workspace.openTextDocument(view.uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preserveFocus, preview: false }));
+        return workspace.openTextDocument(view.uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preserveFocus, preview: false }));
       }
     }
 
@@ -42,7 +42,7 @@ export async function magitStatus(editor: TextEditor, preserveFocus = false): Pr
     const uri = MagitStatusView.encodeLocation(repository);
     views.set(uri.toString(), new MagitStatusView(uri, repository.magitState!));
 
-    return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preserveFocus, preview: false }));
+    return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preserveFocus, preview: false }));
   }
 }
 

--- a/src/commands/visitAtPointCommands.ts
+++ b/src/commands/visitAtPointCommands.ts
@@ -33,7 +33,7 @@ export async function magitVisitAtPoint(repository: MagitRepository, currentView
     if (change.hunks?.length) {
       return visitHunk(selectedView.subViews.find(v => v instanceof HunkView) as HunkView);
     } else {
-      return workspace.openTextDocument(change.uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preview: false }));
+      return workspace.openTextDocument(change.uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preview: false }));
     }
   }
   else if (selectedView instanceof HunkView) {
@@ -66,7 +66,7 @@ async function visitHunk(selectedView: HunkView, activePosition?: Position) {
   const changeHunk = selectedView.changeHunk;
 
   const doc = await workspace.openTextDocument(changeHunk.uri);
-  const editor = await window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preview: false });
+  const editor = await window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preview: false });
 
   try {
     const startLineMatches = changeHunk.diff.match(/(?<=\+)\d+(?=,)/g);
@@ -114,5 +114,5 @@ export async function visitCommit(repository: MagitRepository, commitHash: strin
 
   const uri = CommitDetailView.encodeLocation(repository, commit.hash);
   views.set(uri.toString(), new CommitDetailView(uri, commit));
-  workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preview: false }));
+  workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preview: false }));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,7 +123,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(commands.registerTextEditorCommand('magit.dispatch', Command.primeRepo(async (repository: MagitRepository) => {
     const uri = DispatchView.encodeLocation(repository);
     views.set(uri.toString(), new DispatchView(uri));
-    return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.oppositeActiveViewColumn(), preview: false }));
+    return workspace.openTextDocument(uri).then(doc => window.showTextDocument(doc, { viewColumn: MagitUtils.showDocumentColumn(), preview: false }));
   }, false)));
 
   context.subscriptions.push(commands.registerTextEditorCommand('magit.toggle-fold', Command.primeRepoAndView(async (repo: MagitRepository, view: DocumentView) => {

--- a/src/utils/magitUtils.ts
+++ b/src/utils/magitUtils.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { MagitRepository } from '../models/magitRepository';
 import { magitRepositories, views, gitApi } from '../extension';
 import { window, ViewColumn, Uri, commands } from 'vscode';
@@ -143,8 +144,12 @@ export default class MagitUtils {
     return false;
   }
 
-  public static oppositeActiveViewColumn(): ViewColumn {
+  public static showDocumentColumn(): ViewColumn {
     const activeColumn = window.activeTextEditor?.viewColumn ?? 0;
+
+    if (vscode.workspace.getConfiguration('magit').get('display-buffer-function') === 'same-column') {
+      return activeColumn;
+    }
 
     if (activeColumn > ViewColumn.One) {
       return ViewColumn.One;


### PR DESCRIPTION
Emacs Magit has [`magit-display-buffer-function`](https://magit.vc/manual/magit/Switching-Buffers.html), which you can use to customize where buffers created by Magit get displayed. edamagit currently always displays new buffers in a non-active editor column, as determined by `oppositeActiveViewColumn`.

This pullreq adds an extremely simplified version of `magit-display-buffer-function` to edamagit. Right now there are only two options - `other-column`, which is the current default behavior of displaying new buffers in the "other" editor column, and `same-column`, which always displays new buffers on top of the current buffer.

Personally, I use `magit-display-buffer-same-window-except-diff-v1` in Emacs, which would definitely be implementable here with some more work but I wanted to start with something small. This also adds edamagit's first config option - I feel like the call to `vscode.workspace.getConfiguration` should probably be in some centralized config thing but that seemed like a large change.

Also this plugin is super exciting, ever since I switched to VSCode I've been cmd-tabbing to Emacs just to use Magit 😄.