### PR TITLE
Fix minor issue where highlighting didn't happen unless the cursor was on a word character.

### DIFF
--- a/languages/magit.language-configuration.json
+++ b/languages/magit.language-configuration.json
@@ -1,3 +1,3 @@
 {
-
+    "wordPattern": ".*"
 }


### PR DESCRIPTION
For example - see how the highlight behaves before:
![before](https://user-images.githubusercontent.com/999346/85654053-34714c00-b684-11ea-9c68-3843fe9095a8.gif)

and after:
![after](https://user-images.githubusercontent.com/999346/85654068-39360000-b684-11ea-8da5-74c1d381d885.gif)

