### PR TITLE
Update transpiling target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2018",
     "outDir": "out",
     "lib": [
-      "es6",
+      "es2018",
       "ES2020.String"
     ],
     "sourceMap": true,


### PR DESCRIPTION
This pull request is to update the tranpiling target for target version of vscode.

Since this lib is targeting vscode v1.42.1, I looked at the transpiling target used by the internal extension of vscode at https://github.com/microsoft/vscode/blob/1.42.1/extensions/shared.tsconfig.json.

Moving from es6 to es2018 will allow us to support native async await syntax in the output. This should ideally reduce the size of the output (around 0.8KB) because the output doesn't need to bundle an awaiter function, also should be more performant since it's native to the language(?).