### PR TITLE
Fix regression on view highlight ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ remove the default edamagit bindings and the collisions with the Vim extension.
 _Feature requests as well as issues are welcome_
 
 ### Implement missing Git/Magit features
-  - Diffing (a lot missing)
+  - More diffing features
   - More logging features (https://github.com/kahole/edamagit/pull/40)
   - Bisecting
   - Submodules
@@ -150,5 +150,3 @@ _Feature requests as well as issues are welcome_
 ### Interface
 - Config menus
 - Options/variable menus
-- Branch name highlighting     
-     (https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview)

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,9 +78,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-			"integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
+			"integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -378,6 +378,26 @@
         "path": "./syntaxes/magit.tmGrammar.json"
       }
     ],
+    "semanticTokenTypes": [
+      {
+        "id": "magit-ref-name",
+        "superType": "label",
+        "description": "Name of a git ref."
+      },
+      {
+        "id": "magit-remote-ref-name",
+        "superType": "label",
+        "description": "Name of a git ref from a remote."
+      }
+    ],
+    "semanticTokenScopes": [
+      {
+        "scopes": {
+          "magit-ref-name": ["entity.name.type.template"],
+          "magit-remote-ref-name": ["variable.other.constant"]
+        }
+      }
+    ],
     "keybindings": [
       {
         "command": "magit.status",
@@ -599,7 +619,7 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.1",
     "@types/node": "^12.11.7",
-    "@types/vscode": "^1.42.1",
+    "@types/vscode": "^1.46.0",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
     "eslint": "^6.8.0",

--- a/src/commands/loggingCommands.ts
+++ b/src/commands/loggingCommands.ts
@@ -148,7 +148,7 @@ function parseLog(stdout: string) {
         const graph = matches[1]; // undefined if graph doesn't exist
         const log = {
           graph: graph ? [graph] : undefined,
-          refs: matches[4],
+          refs: (matches[4] ?? '').split(', ').filter((m: string) => m),
           author: matches[6],
           time: new Date(Number(matches[8]) * 1000), // convert seconds to milliseconds
           commit: {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -18,3 +18,9 @@ export const BranchDecoration = window.createTextEditorDecorationType({
 export const RemoteBranchDecoration = window.createTextEditorDecorationType({
   color: 'rgba(152,238,152,1.0)'
 });
+
+// Must match the semanticTokenTypes in package.json
+export const SemanticTokenTypes = [
+  'magit-ref-name',
+  'magit-remote-ref-name',
+] as const;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { magitCommit } from './commands/commitCommands';
 import { magitStage, magitStageAll, magitUnstageAll, magitUnstage, stageFile, unstageFile } from './commands/stagingCommands';
 import { saveClose, clearSaveClose, quitMagitView } from './commands/macros';
 import HighlightProvider from './providers/highlightProvider';
+import SemanticTokensProvider from './providers/semanticTokensProvider';
 import { Command } from './commands/commandPrimer';
 import * as Constants from './common/constants';
 import { fetching } from './commands/fetchingCommands';
@@ -68,10 +69,12 @@ export function activate(context: ExtensionContext) {
 
   const contentProvider = new ContentProvider();
   const highlightProvider = new HighlightProvider();
+  const semanticTokensProvider = new SemanticTokensProvider();
 
   const providerRegistrations = Disposable.from(
     workspace.registerTextDocumentContentProvider(Constants.MagitUriScheme, contentProvider),
-    languages.registerDocumentHighlightProvider(Constants.MagitDocumentSelector, highlightProvider)
+    languages.registerDocumentHighlightProvider(Constants.MagitDocumentSelector, highlightProvider),
+    languages.registerDocumentSemanticTokensProvider(Constants.MagitDocumentSelector, semanticTokensProvider, semanticTokensProvider.legend),
   );
   context.subscriptions.push(
     contentProvider,

--- a/src/models/magitLogCommit.ts
+++ b/src/models/magitLogCommit.ts
@@ -3,7 +3,7 @@ import { Commit } from '../typings/git';
 export interface MagitLogEntry {
   commit: Commit;
   graph: string[] | undefined;
-  refs: string | undefined;
+  refs: string[];
   author: string;
   time: Date;
 }

--- a/src/providers/contentProvider.ts
+++ b/src/providers/contentProvider.ts
@@ -49,7 +49,7 @@ export default class ContentProvider implements vscode.TextDocumentContentProvid
 
     if (view) {
       view.emitter = this.viewUpdatedEmitter;
-      return view.render(0).join('\n');
+      return view.render(0, 0);
     }
     return '';
   }

--- a/src/providers/semanticTokensProvider.ts
+++ b/src/providers/semanticTokensProvider.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import { views } from '../extension';
+import { TokenView } from '../views/general/tokenView';
+import { View } from '../views/general/view';
+import { SemanticTokenTypes } from '../common/constants';
+
+export default class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+
+  readonly legend = new vscode.SemanticTokensLegend([...SemanticTokenTypes], []);
+
+  dispose() { }
+
+  provideDocumentSemanticTokens(document: vscode.TextDocument): vscode.ProviderResult<vscode.SemanticTokens> {
+    const currentView = views.get(document.uri.toString());
+    const builder = new vscode.SemanticTokensBuilder(this.legend);
+    if (currentView) {
+      this.visitNode(currentView, builder);
+    }
+    return builder.build();
+  }
+
+  visitNode(view: View, builder: vscode.SemanticTokensBuilder) {
+    if (view instanceof TokenView) {
+      builder.push(view.range, view.tokenType);
+    }
+    if (!view.folded) {
+      view.subViews.forEach(v => this.visitNode(v, builder));
+    }
+  }
+}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -38,7 +38,7 @@ suite('Extension Test Suite', () => {
 
     const statusView = new MagitStatusView(vscode.Uri.parse(''), magitState);
 
-    const result = statusView.render(0).join('\n');
+    const result = statusView.render(0, 0);
 
     assert.equal(result, expected);
   });

--- a/src/views/branches/branchHeaderView.ts
+++ b/src/views/branches/branchHeaderView.ts
@@ -1,13 +1,17 @@
+import { View } from '../general/view';
 import { TextView } from '../general/textView';
 import { MagitBranch } from '../../models/magitBranch';
 import GitTextUtils from '../../utils/gitTextUtils';
+import { TokenView } from '../general/tokenView';
 
-export class BranchHeaderView extends TextView {
+export class BranchHeaderView extends View {
 
   constructor(name: string, branch: MagitBranch) {
     super();
     const nameLabel = `${name}:`.padEnd(10);
-    this.textContent = `${nameLabel}${branch.name ?? GitTextUtils.shortHash(branch.commit)} ${GitTextUtils.shortCommitMessage(branch.commitDetails.message)}`;
+    this.addSubview(new TextView(nameLabel));
+    this.addSubview(new TokenView(branch.name ?? GitTextUtils.shortHash(branch.commit), 'magit-ref-name'));
+    this.addSubview(new TextView(` ${GitTextUtils.shortCommitMessage(branch.commitDetails.message)}`));
   }
 
   onClicked() { return undefined; }

--- a/src/views/branches/branchListingView.ts
+++ b/src/views/branches/branchListingView.ts
@@ -1,11 +1,13 @@
 import { Ref } from '../../typings/git';
+import { View } from '../general/view';
 import { TextView } from '../general/textView';
 
-export class BranchListingView extends TextView {
+export class BranchListingView extends View {
 
   get id() { return this.ref.name?.toString() + this.ref.type.toString(); }
 
   constructor(public ref: Ref, active = false) {
-    super(`${active ? '*' : ' '} ${ref.name}`);
+    super();
+    this.addSubview(new TextView(`${active ? '*' : ' '} ${ref.name}`));
   }
 }

--- a/src/views/branches/branchesSectionView.ts
+++ b/src/views/branches/branchesSectionView.ts
@@ -1,12 +1,12 @@
 import { View } from '../general/view';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
-import { LineBreakView } from '../general/lineBreakView';
 import { Ref } from '../../typings/git';
 import { BranchListingView } from './branchListingView';
 import { MagitBranch } from '../../models/magitBranch';
 
 export class BranchesSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return Section.Branches.toString(); }
 
@@ -15,7 +15,6 @@ export class BranchesSectionView extends View {
     this.subViews = [
       new SectionHeaderView(Section.Branches, branches.length),
       ...branches.map(branch => new BranchListingView(branch, branch.name === HEAD?.name)),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/branches/remoteBranchHeaderView.ts
+++ b/src/views/branches/remoteBranchHeaderView.ts
@@ -1,12 +1,16 @@
+import { View } from '../general/view';
 import { TextView } from '../general/textView';
+import { TokenView } from '../general/tokenView';
 import { MagitUpstreamRef } from '../../models/magitBranch';
 import GitTextUtils from '../../utils/gitTextUtils';
 
-export class RemoteBranchHeaderView extends TextView {
+export class RemoteBranchHeaderView extends View {
 
   constructor(name: string, upstreamRef: MagitUpstreamRef) {
     super();
     const nameLabel = `${name}:`.padEnd(10);
-    this.textContent = `${nameLabel}${upstreamRef.remote}/${upstreamRef.name} ${GitTextUtils.shortCommitMessage(upstreamRef.commit?.message)}`;
+    this.addSubview(new TextView(`${nameLabel }`));
+    this.addSubview(new TokenView(`${upstreamRef.remote}/${upstreamRef.name}`, 'magit-remote-ref-name'));
+    this.addSubview(new TextView(` ${GitTextUtils.shortCommitMessage(upstreamRef.commit?.message)}`));
   }
 }

--- a/src/views/changes/changeHeaderView.ts
+++ b/src/views/changes/changeHeaderView.ts
@@ -1,14 +1,15 @@
+import { View } from '../general/view';
 import { TextView } from '../general/textView';
 import { MagitChange } from '../../models/magitChange';
 import { Status } from '../../typings/git';
 
-export class ChangeHeaderView extends TextView {
+export class ChangeHeaderView extends View {
 
   constructor(private change: MagitChange) {
     super();
     const statusLabel = mapFileStatusToLabel(this.change.status);
     const mergingStatusLabel = mapFileStatusToMergingLabel(this.change.status);
-    this.textContent = `${statusLabel ? statusLabel + '   ' : ''}${this.change.relativePath}${mergingStatusLabel ? ` (${mergingStatusLabel})` : ''}`;
+    this.addSubview(new TextView(`${statusLabel ? statusLabel + '   ' : ''}${this.change.relativePath}${mergingStatusLabel ? ` (${mergingStatusLabel})` : ''}`));
   }
 
   onClicked() { return undefined; }

--- a/src/views/changes/changesSectionView.ts
+++ b/src/views/changes/changesSectionView.ts
@@ -2,10 +2,10 @@ import { View } from '../general/view';
 import { MagitChange } from '../../models/magitChange';
 import { ChangeView } from './changeView';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
-import { LineBreakView } from '../general/lineBreakView';
 
 export class ChangeSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return this.section.toString() + this.context; }
 
@@ -14,7 +14,6 @@ export class ChangeSectionView extends View {
     this.subViews = [
       new SectionHeaderView(section, changes.length),
       ...changes.map(change => new ChangeView(change, context)),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/changes/hunkView.ts
+++ b/src/views/changes/hunkView.ts
@@ -1,12 +1,14 @@
 import { MagitChangeHunk } from '../../models/magitChangeHunk';
+import { View } from '../general/view';
 import { TextView } from '../general/textView';
 
-export class HunkView extends TextView {
+export class HunkView extends View {
   isFoldable = true;
 
   get id() { return this.changeHunk.diff; }
 
   constructor(public changeHunk: MagitChangeHunk) {
-    super(changeHunk.diff);
+    super();
+    this.addSubview(new TextView(changeHunk.diff));
   }
 }

--- a/src/views/cherryPicking/cherryPickingSectionView.ts
+++ b/src/views/cherryPicking/cherryPickingSectionView.ts
@@ -1,5 +1,4 @@
 import { View } from '../general/view';
-import { LineBreakView } from '../general/lineBreakView';
 import { MagitCherryPickingState } from '../../models/magitCherryPickingState';
 import { SectionHeaderView, Section } from '../general/sectionHeader';
 import { Commit } from '../../typings/git';
@@ -7,6 +6,7 @@ import { CommitItemView } from '../commits/commitSectionView';
 
 export class CherryPickingSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return 'CherryPicking'; }
 
@@ -28,7 +28,6 @@ export class CherryPickingSectionView extends View {
       new CommitItemView(cherryPickingState.currentCommit, 'join'),
       ...doneCommits.map(commit => new CommitItemView(commit, 'done')),
       new CommitItemView(cherryPickingState.originalHead, 'onto'),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/commits/commitSectionView.ts
+++ b/src/views/commits/commitSectionView.ts
@@ -1,7 +1,8 @@
 import { View } from '../general/view';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
+import { TokenView } from '../general/tokenView';
 import { TextView } from '../general/textView';
-import { Commit } from '../../typings/git';
+import { Commit, Ref } from '../../typings/git';
 import { LineBreakView } from '../general/lineBreakView';
 import GitTextUtils from '../../utils/gitTextUtils';
 
@@ -10,19 +11,27 @@ export class CommitSectionView extends View {
 
   get id() { return this.section.toString(); }
 
-  constructor(private section: Section, commits: Commit[]) {
+  constructor(private section: Section, commits: Commit[], refs?: Ref[]) {
     super();
     this.subViews = [
       new SectionHeaderView(section),
-      ...commits.map(commit => new CommitItemView(commit)),
+      ...commits.map(commit => new CommitItemView(commit, undefined, refs)),
       new LineBreakView()
     ];
   }
 }
 
-export class CommitItemView extends TextView {
+export class CommitItemView extends View {
 
-  constructor(public commit: Commit, qualifier?: string) {
-    super(`${qualifier ? qualifier + ' ' : ''}${GitTextUtils.shortHash(commit.hash)} ${GitTextUtils.shortCommitMessage(commit.message)}`);
+  constructor(public commit: Commit, qualifier?: string, refs?: Ref[]) {
+    super();
+    this.subViews = [];
+    this.addSubview(new TextView(`${qualifier ? qualifier + ' ' : ''}${GitTextUtils.shortHash(commit.hash)} `));
+    const matchingRefs = (refs ?? [])?.filter(ref => ref.commit === commit.hash);
+    matchingRefs.forEach(ref => {
+      this.addSubview(new TokenView(ref.name ?? '', ref.remote ? 'magit-remote-ref-name' : 'magit-ref-name'));
+      this.addSubview(new TextView(' '));
+    });
+    this.addSubview(new TextView(`${GitTextUtils.shortCommitMessage(commit.message)}`));
   }
 }

--- a/src/views/commits/commitSectionView.ts
+++ b/src/views/commits/commitSectionView.ts
@@ -3,11 +3,11 @@ import { Section, SectionHeaderView } from '../general/sectionHeader';
 import { TokenView } from '../general/tokenView';
 import { TextView } from '../general/textView';
 import { Commit, Ref } from '../../typings/git';
-import { LineBreakView } from '../general/lineBreakView';
 import GitTextUtils from '../../utils/gitTextUtils';
 
 export class CommitSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return this.section.toString(); }
 
@@ -16,7 +16,6 @@ export class CommitSectionView extends View {
     this.subViews = [
       new SectionHeaderView(section),
       ...commits.map(commit => new CommitItemView(commit, undefined, refs)),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/commits/unsourcedCommitsSectionView.ts
+++ b/src/views/commits/unsourcedCommitsSectionView.ts
@@ -1,11 +1,11 @@
 import { View } from '../general/view';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
 import { Commit, UpstreamRef, Ref } from '../../typings/git';
-import { LineBreakView } from '../general/lineBreakView';
 import { CommitItemView } from './commitSectionView';
 
 export class UnsourcedCommitSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return this.section.toString(); }
 
@@ -14,7 +14,6 @@ export class UnsourcedCommitSectionView extends View {
     this.subViews = [
       new SectionHeaderView(section, commits.length, `${upstream.remote}/${upstream.name}`),
       ...commits.map(commit => new CommitItemView(commit, undefined, refs)),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/commits/unsourcedCommitsSectionView.ts
+++ b/src/views/commits/unsourcedCommitsSectionView.ts
@@ -1,6 +1,6 @@
 import { View } from '../general/view';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
-import { Commit, UpstreamRef } from '../../typings/git';
+import { Commit, UpstreamRef, Ref } from '../../typings/git';
 import { LineBreakView } from '../general/lineBreakView';
 import { CommitItemView } from './commitSectionView';
 
@@ -9,11 +9,11 @@ export class UnsourcedCommitSectionView extends View {
 
   get id() { return this.section.toString(); }
 
-  constructor(private section: Section, upstream: UpstreamRef, commits: Commit[]) {
+  constructor(private section: Section, upstream: UpstreamRef, commits: Commit[], refs: Ref[]) {
     super();
     this.subViews = [
       new SectionHeaderView(section, commits.length, `${upstream.remote}/${upstream.name}`),
-      ...commits.map(commit => new CommitItemView(commit)),
+      ...commits.map(commit => new CommitItemView(commit, undefined, refs)),
       new LineBreakView()
     ];
   }

--- a/src/views/general/documentView.ts
+++ b/src/views/general/documentView.ts
@@ -1,6 +1,7 @@
 import { View } from './view';
 import { Uri, EventEmitter } from 'vscode';
 import { MagitState } from '../../models/magitState';
+import * as Constants from '../../common/constants';
 
 export abstract class DocumentView extends View {
 
@@ -11,6 +12,16 @@ export abstract class DocumentView extends View {
 
   constructor(public uri: Uri) {
     super();
+  }
+
+  render(startLineNumber: number, startCharacterNumber: number) {
+    let rendered = super.render(startLineNumber, startCharacterNumber);
+    if (Constants.FinalLineBreakRegex.test(rendered)) {
+      return rendered;
+    }
+    rendered += '\n';
+    this.range = this.range.with(undefined, this.range.end.with(this.range.end.line + 1, 0));
+    return rendered;
   }
 
   public abstract update(state: MagitState): void;

--- a/src/views/general/documentView.ts
+++ b/src/views/general/documentView.ts
@@ -4,6 +4,8 @@ import { MagitState } from '../../models/magitState';
 
 export abstract class DocumentView extends View {
 
+  isHighlightable = false;
+
   public emitter?: EventEmitter<Uri>;
   needsUpdate: boolean = true;
 

--- a/src/views/general/lineBreakView.ts
+++ b/src/views/general/lineBreakView.ts
@@ -1,8 +1,12 @@
+import { View } from './view';
 import { TextView } from './textView';
 
-export class LineBreakView extends TextView {
+export class LineBreakView extends View {
 
   constructor(number: number = 1) {
-    super('\n'.repeat(number - 1));
+    super();
+    this.addSubview(new TextView('\n'.repeat(number)));
   }
+
+  onClicked() { return undefined; }
 }

--- a/src/views/general/sectionHeader.ts
+++ b/src/views/general/sectionHeader.ts
@@ -1,4 +1,5 @@
 import { TextView } from './textView';
+import { View } from './view';
 
 export enum Section {
   Untracked = 'Untracked files',
@@ -18,10 +19,11 @@ export enum Section {
   Tags = 'Tags'
 }
 
-export class SectionHeaderView extends TextView {
+export class SectionHeaderView extends View {
 
   constructor(private _section: Section, count?: number, extraText?: string) {
-    super(`${_section.valueOf()}${extraText ? ' ' + extraText + '' : ''}${count ? ' (' + count + ')' : ''}`);
+    super();
+    this.addSubview(new TextView(`${_section.valueOf()}${extraText ? ' ' + extraText + '' : ''}${count ? ' (' + count + ')' : ''}`));
   }
 
   onClicked() { return undefined; }

--- a/src/views/general/textView.ts
+++ b/src/views/general/textView.ts
@@ -4,17 +4,27 @@ import * as Constants from '../../common/constants';
 
 export class TextView extends View {
 
+  isHighlightable = false;
+
   constructor(public textContent: string = '') {
     super();
   }
 
-  render(startLineNumber: number): string[] {
-
-    this.retrieveFold();
-
+  render(startLineNumber: number, startCharacterNumber: number): string {
     const lines = this.textContent.split(Constants.LineSplitterRegex);
-    this.range = new Range(startLineNumber, 0, startLineNumber + lines.length - 1, lines[lines.length - 1].length);
-
-    return [this.folded ? lines[0] : this.textContent];
+    // If our content ends in a newline, we want to exclude that newline from our range.
+    // If we don't do this, our range will include the first character of the line after us.
+    if (lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+    this.range = new Range(
+      startLineNumber,
+      startCharacterNumber,
+      startLineNumber + lines.length - 1,
+      lines.length === 1 ? startCharacterNumber + lines[0].length : lines[lines.length - 1].length,
+    );
+    return this.textContent;
   }
+
+  onClicked() { return undefined; }
 }

--- a/src/views/general/tokenView.ts
+++ b/src/views/general/tokenView.ts
@@ -1,0 +1,9 @@
+import { TextView } from './textView';
+import { SemanticTokenTypes } from '../../common/constants';
+
+export class TokenView extends TextView {
+
+  constructor(public textContent: string = '', public tokenType: typeof SemanticTokenTypes[number]) {
+    super(textContent);
+  }
+}

--- a/src/views/general/view.ts
+++ b/src/views/general/view.ts
@@ -40,7 +40,7 @@ export abstract class View {
   render(startLineNumber: number, startCharacterNumber: number): string {
 
     this.retrieveFold();
-  
+
     let renderedContent: string = '';
     // If we're not at the beginning of a line, add a new line.
     // This view's range begins at the start of this new line.

--- a/src/views/general/view.ts
+++ b/src/views/general/view.ts
@@ -1,4 +1,5 @@
 import { Range, Position } from 'vscode';
+import * as Constants from '../../common/constants';
 
 const viewFoldStatusMemory: Map<string, boolean> = new Map<string, boolean>();
 
@@ -23,9 +24,6 @@ export abstract class View {
   }
 
   get range(): Range {
-    if (this.folded) {
-      return new Range(this._range.start, new Position(this._range.start.line, 300));
-    }
     return this._range;
   }
 
@@ -39,30 +37,56 @@ export abstract class View {
     }
   }
 
-  render(startLineNumber: number): string[] {
+  render(startLineNumber: number, startCharacterNumber: number): string {
 
     this.retrieveFold();
+  
+    let renderedContent: string = '';
+    // If we're not at the beginning of a line, add a new line.
+    // This view's range begins at the start of this new line.
+    if (startCharacterNumber !== 0) {
+      startLineNumber += 1;
+      startCharacterNumber = 0;
+      renderedContent += '\n';
+    }
 
     let currentLineNumber = startLineNumber;
-    const renderedContent: string[] = [];
+    let currentCharacterNumber = startCharacterNumber;
+    let subViewRender: string | undefined = undefined;
 
-    this.subViews.forEach(
-      v => {
-        const subViewRender = v.render(currentLineNumber);
-        currentLineNumber += (v.range.end.line - v.range.start.line) + 1;
-        renderedContent.push(...subViewRender);
+    for (const v of this.subViews) {
+      // If the last subview we rendered ends in a newline, its range will exclude that newline.
+      // That means the range of our next subview will start on the line after the last subview's range.
+      if (Constants.FinalLineBreakRegex.test(subViewRender ?? '')) {
+        currentLineNumber += 1;
+        currentCharacterNumber = 0;
       }
-    );
-    this.range = new Range(startLineNumber, 0, currentLineNumber - 1, renderedContent.length > 0 ? renderedContent[renderedContent.length - 1].length : 0);
+      subViewRender = v.render(currentLineNumber, currentCharacterNumber);
+      // If this view is folded, trim whatever the subviews render to only the first line, and adjust
+      // the range accordingly.
+      const foldEnding = this.folded ? subViewRender.search(Constants.LineSplitterRegex) : -1;
+      if (foldEnding !== -1) {
+        const foldedRender = subViewRender.slice(0, foldEnding);
+        currentCharacterNumber += foldedRender.length;
+        renderedContent += foldedRender;
+        // If this view is folded and we've already rendered a full line, then there's no point rendering any more.
+        break;
+      } else {
+        currentLineNumber = v.range.end.line;
+        currentCharacterNumber = v.range.end.character;
+        renderedContent += subViewRender;
+      }
+    }
+    this.range = new Range(startLineNumber, startCharacterNumber, currentLineNumber, currentCharacterNumber);
 
-    return this.folded ? renderedContent.slice(0, 1) : renderedContent;
+    return renderedContent;
   }
 
   get id(): string | undefined { return undefined; }
 
   onClicked(): View | undefined { return this; }
 
-  click(position: Position): View | undefined {
+  click(position: Position | Range): View | undefined {
     if (this.range.contains(position)) {
       const result = this.onClicked();
 

--- a/src/views/logView.ts
+++ b/src/views/logView.ts
@@ -9,9 +9,11 @@ import GitTextUtils from '../utils/gitTextUtils';
 import { CommitItemView } from './commits/commitSectionView';
 import { DocumentView } from './general/documentView';
 import { TextView } from './general/textView';
+import { TokenView } from './general/tokenView';
 
 export default class LogView extends DocumentView {
 
+  isHighlightable = false;
   static UriPath: string = 'log.magit';
 
   constructor(uri: Uri, log: MagitLog) {
@@ -38,18 +40,36 @@ export class CommitLongFormItemView extends CommitItemView {
     const timeDistance = formatDistanceToNowStrict(logEntry.time);
     const hash = `${GitTextUtils.shortHash(logEntry.commit.hash)} `;
     const graph = logEntry.graph?.[0] ?? '';
-    const refs = logEntry.refs ? `(${logEntry.refs}) ` : '';
+    this.subViews = [];
+
     const msg = GitTextUtils.shortCommitMessage(logEntry.commit.message);
-    this.textContent = truncateText(`${hash}${graph}${refs}${msg}`, 69, 70) +
-      truncateText(logEntry.author, 17, 18) +
-      timeDistance;
+    const textViews: TextView[] = [];
+    textViews.push(new TextView(`${hash}${graph}`));
+
+    const refViews: TextView[] = logEntry.refs.map(ref => new TokenView(ref, 'magit-ref-name'));
+    if (refViews.length) {
+      textViews.push(new TextView('('));
+      refViews.forEach((v, idx) => {
+        textViews.push(v);
+        if (idx < refViews.length - 1) {
+          textViews.push(new TextView(', '));
+        }
+      });
+      textViews.push(new TextView(') '));
+    }
+    this.addSubview(...textViews);
+
+    const availableMsgWidth = 70  - textViews.reduce((prev, v) => prev + v.textContent.length, 0);
+    const truncatedAuthor = truncateText(logEntry.author, 17, 18);
+    const truncatedMsg = truncateText(msg, availableMsgWidth, availableMsgWidth + 1);
+    this.addSubview(new TextView(`${truncatedMsg}${truncatedAuthor}${timeDistance}`));
 
     // Add the rest of the graph for this commit
     if (logEntry.graph) {
       for (let i = 1; i < logEntry.graph.length; i++) {
         const g = logEntry.graph[i];
         const emptyHashSpace = ' '.repeat(8);
-        this.textContent += `\n${emptyHashSpace}${g}`;
+        this.addSubview(new TextView(`\n${emptyHashSpace}${g}`));
       }
     }
   }

--- a/src/views/magitStatusView.ts
+++ b/src/views/magitStatusView.ts
@@ -94,7 +94,7 @@ export default class MagitStatusView extends DocumentView {
     this.triggerUpdate();
   }
 
-  static encodeLocation(repository: MagitRepository, ): Uri {
+  static encodeLocation(repository: MagitRepository): Uri {
     return Uri.parse(`${Constants.MagitUriScheme}:${MagitStatusView.UriPath}?${repository.rootUri.fsPath}`);
   }
 }

--- a/src/views/magitStatusView.ts
+++ b/src/views/magitStatusView.ts
@@ -70,20 +70,22 @@ export default class MagitStatusView extends DocumentView {
       this.addSubview(new StashSectionView(magitState.stashes));
     }
 
+    const refs = magitState.remotes.reduce((prev, remote) => remote.branches.concat(prev), magitState.branches);
+
     if (magitState.HEAD?.upstreamRemote?.commitsAhead?.length) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnmergedInto, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsAhead));
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnmergedInto, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsAhead, refs));
     } else if (magitState.HEAD?.pushRemote?.commitsAhead?.length) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnpushedTo, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsAhead));
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnpushedTo, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsAhead, refs));
     }
 
     if (magitState.log.length > 0 && !magitState.HEAD?.upstreamRemote?.commitsAhead?.length) {
-      this.addSubview(new CommitSectionView(Section.RecentCommits, magitState.log.slice(0, 10)));
+      this.addSubview(new CommitSectionView(Section.RecentCommits, magitState.log.slice(0, 10), refs));
     }
 
     if (magitState.HEAD?.upstreamRemote?.commitsBehind?.length) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsBehind));
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsBehind, refs));
     } else if (magitState.HEAD?.pushRemote?.commitsBehind?.length) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsBehind));
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsBehind, refs));
     }
   }
 

--- a/src/views/merging/mergingSectionView.ts
+++ b/src/views/merging/mergingSectionView.ts
@@ -1,12 +1,11 @@
 import { View } from '../general/view';
-import { TextView } from '../general/textView';
-import { LineBreakView } from '../general/lineBreakView';
 import { MagitMergingState } from '../../models/magitMergingState';
 import { CommitItemView } from '../commits/commitSectionView';
 import { SectionHeaderView, Section } from '../general/sectionHeader';
 
 export class MergingSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return 'Merging'; }
 
@@ -15,7 +14,6 @@ export class MergingSectionView extends View {
     this.subViews = [
       new SectionHeaderView(Section.Merging, mergingState.commits.length, `${mergingState.mergingBranches[0]}`),
       ...mergingState.commits.map(commit => new CommitItemView(commit)),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/rebasing/rebasingSectionView.ts
+++ b/src/views/rebasing/rebasingSectionView.ts
@@ -1,11 +1,11 @@
 import { View } from '../general/view';
 import { TextView } from '../general/textView';
-import { LineBreakView } from '../general/lineBreakView';
 import { CommitItemView } from '../commits/commitSectionView';
 import { MagitRebasingState } from '../../models/magitRebasingState';
 
 export class RebasingSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return 'Rebasing'; }
 
@@ -17,7 +17,6 @@ export class RebasingSectionView extends View {
       new CommitItemView(rebasingState.currentCommit, 'join'),
       ...rebasingState.doneCommits.map(c => new CommitItemView(c, 'done')),
       new CommitItemView(rebasingState.ontoBranch.commitDetails, 'onto'),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/rebasing/rebasingSectionView.ts
+++ b/src/views/rebasing/rebasingSectionView.ts
@@ -22,10 +22,11 @@ export class RebasingSectionView extends View {
   }
 }
 
-class RebaseSectionHeaderView extends TextView {
+class RebaseSectionHeaderView extends View {
 
   constructor(text: string) {
-    super(text);
+    super();
+    this.addSubview(new TextView(text));
   }
 
   onClicked() { return undefined; }

--- a/src/views/remotes/remoteBranchListingView.ts
+++ b/src/views/remotes/remoteBranchListingView.ts
@@ -1,7 +1,8 @@
 import { Ref } from '../../typings/git';
+import { View } from '../general/view';
 import { TextView } from '../general/textView';
 
-export class RemoteBranchListingView extends TextView {
+export class RemoteBranchListingView extends View {
 
   get id() { return this.ref.name?.toString() + this.ref.type.toString(); }
 
@@ -11,6 +12,6 @@ export class RemoteBranchListingView extends TextView {
     const [remote, ...nameParts] = ref.name?.split('/') ?? [];
     const name = nameParts.join('/');
 
-    this.textContent = `  ${name}`;
+    this.addSubview(new TextView(`  ${name}`));
   }
 }

--- a/src/views/remotes/remoteSectionView.ts
+++ b/src/views/remotes/remoteSectionView.ts
@@ -1,11 +1,11 @@
 import { View } from '../general/view';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
-import { LineBreakView } from '../general/lineBreakView';
 import { RemoteBranchListingView } from './remoteBranchListingView';
 import { MagitRemote } from '../../models/magitRemote';
 
 export class RemoteSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return `${Section.Remote.toString()} ${this.remote.name} (${this.remote.fetchUrl ?? this.remote.pushUrl})`; }
 
@@ -14,7 +14,6 @@ export class RemoteSectionView extends View {
     this.subViews = [
       new SectionHeaderView(Section.Remote, remote.branches.length, `${remote.name} (${remote.fetchUrl ?? remote.pushUrl})`),
       ...remote.branches.map(branch => new RemoteBranchListingView(branch)),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/reverting/revertingSectionView.ts
+++ b/src/views/reverting/revertingSectionView.ts
@@ -1,6 +1,4 @@
 import { View } from '../general/view';
-import { LineBreakView } from '../general/lineBreakView';
-import { MagitCherryPickingState } from '../../models/magitCherryPickingState';
 import { SectionHeaderView, Section } from '../general/sectionHeader';
 import { Commit } from '../../typings/git';
 import { CommitItemView } from '../commits/commitSectionView';
@@ -8,6 +6,7 @@ import { MagitRevertingState } from '../../models/magitRevertingState';
 
 export class RevertingSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return 'Reverting'; }
 
@@ -29,7 +28,6 @@ export class RevertingSectionView extends View {
       new CommitItemView(revertingState.currentCommit, 'join'),
       ...doneCommits.map(commit => new CommitItemView(commit, 'done')),
       new CommitItemView(revertingState.originalHead, 'onto'),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/stashes/stashSectionView.ts
+++ b/src/views/stashes/stashSectionView.ts
@@ -19,9 +19,10 @@ export class StashSectionView extends View {
   }
 }
 
-export class StashItemView extends TextView {
+export class StashItemView extends View {
 
   constructor(public stash: Stash) {
-    super(`stash@{${stash.index}} ${stash.description}`);
+    super();
+    this.addSubview(new TextView(`stash@{${stash.index}} ${stash.description}`));
   }
 }

--- a/src/views/stashes/stashSectionView.ts
+++ b/src/views/stashes/stashSectionView.ts
@@ -2,10 +2,10 @@ import { View } from '../general/view';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
 import { Stash } from '../../common/gitApiExtensions';
 import { TextView } from '../general/textView';
-import { LineBreakView } from '../general/lineBreakView';
 
 export class StashSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return Section.Stashes.toString(); }
 
@@ -14,7 +14,6 @@ export class StashSectionView extends View {
     this.subViews = [
       new SectionHeaderView(Section.Stashes, stashes.length),
       ...stashes.map(stash => new StashItemView(stash)),
-      new LineBreakView()
     ];
   }
 }

--- a/src/views/tags/tagListingView.ts
+++ b/src/views/tags/tagListingView.ts
@@ -1,11 +1,13 @@
 import { Ref } from '../../typings/git';
+import { View } from '../general/view';
 import { TextView } from '../general/textView';
 
-export class TagListingView extends TextView {
+export class TagListingView extends View {
 
   get id() { return this.ref.name?.toString() + this.ref.type.toString(); }
 
   constructor(public ref: Ref) {
-    super(`  ${ref.name}`);
+    super();
+    this.addSubview(new TextView(`  ${ref.name}`));
   }
 }

--- a/src/views/tags/tagSectionView.ts
+++ b/src/views/tags/tagSectionView.ts
@@ -1,11 +1,11 @@
 import { View } from '../general/view';
 import { Section, SectionHeaderView } from '../general/sectionHeader';
-import { LineBreakView } from '../general/lineBreakView';
 import { TagListingView } from './tagListingView';
 import { Ref } from '../../typings/git';
 
 export class TagSectionView extends View {
   isFoldable = true;
+  afterMargin = 1;
 
   get id() { return Section.Tags.toString(); }
 
@@ -14,7 +14,6 @@ export class TagSectionView extends View {
     this.subViews = [
       new SectionHeaderView(Section.Tags, tags.length),
       ...tags.map(tag => new TagListingView(tag)),
-      new LineBreakView()
     ];
   }
 }


### PR DESCRIPTION
Fixes bugs from https://github.com/kahole/edamagit/pull/55#issuecomment-658287625.

The problem here was that `ChangeSectionView`, for example, had a `LineBreakView` as one of its subviews to create a margin between it and the next view. This caused the `ChangeSectionView`'s range to include that line break. Now, instead of trailing `LineBreakView`s, I added an `afterMargin` property to `View`s so that views can request a margin between themselves and the next view without affecting their range.