### PR TITLE
Implement basic copy section value command

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,10 @@
       {
         "command": "magit.unstage-file",
         "title": "Magit Unstage File"
+      },
+      {
+        "command": "magit.copy-section-value",
+        "title": "Magit Copy Section value"
       }
     ],
     "menus": {

--- a/src/commands/copySectionValueCommands.ts
+++ b/src/commands/copySectionValueCommands.ts
@@ -38,7 +38,7 @@ export async function copySectionValueCommand(repository: MagitRepository, curre
   }
 
   if (sectionValue) {
-    env.clipboard.writeText(sectionValue);
+    await env.clipboard.writeText(sectionValue);
     window.setStatusBarMessage(sectionValue, Constants.StatusMessageDisplayTimeout);
   }
 }

--- a/src/commands/copySectionValueCommands.ts
+++ b/src/commands/copySectionValueCommands.ts
@@ -1,0 +1,44 @@
+import { env, window } from 'vscode';
+import * as Constants from '../common/constants';
+import { MagitRepository } from '../models/magitRepository';
+import { BranchListingView } from '../views/branches/branchListingView';
+import { ChangeHeaderView } from '../views/changes/changeHeaderView';
+import { CommitItemView } from '../views/commits/commitSectionView';
+import { DocumentView } from '../views/general/documentView';
+import { RemoteBranchListingView } from '../views/remotes/remoteBranchListingView';
+import { StashItemView } from '../views/stashes/stashSectionView';
+import { TagListingView } from '../views/tags/tagListingView';
+import { ChangeView } from '../views/changes/changeView';
+
+export async function copySectionValueCommand(repository: MagitRepository, currentView: DocumentView) {
+
+  const activePosition = window.activeTextEditor?.selection.active;
+
+  if (!activePosition) {
+    return;
+  }
+
+  let sectionValue: string | undefined;
+  const selectedView = currentView.click(activePosition);
+  if (selectedView instanceof CommitItemView) {
+    sectionValue = selectedView.commit.hash;
+  } else if (
+    selectedView instanceof BranchListingView ||
+    selectedView instanceof RemoteBranchListingView ||
+    selectedView instanceof TagListingView
+  ) {
+    sectionValue = selectedView.ref.commit;
+  } else if (selectedView instanceof StashItemView) {
+    sectionValue = selectedView.section;
+  } else if (
+    selectedView instanceof ChangeView ||
+    selectedView instanceof ChangeHeaderView
+  ) {
+    sectionValue = selectedView.change.relativePath;
+  }
+
+  if (sectionValue) {
+    env.clipboard.writeText(sectionValue);
+    window.setStatusBarMessage(sectionValue, Constants.StatusMessageDisplayTimeout);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,7 @@ import { cherryPicking } from './commands/cherryPickingCommands';
 import { reverting } from './commands/revertingCommands';
 import { reverseAtPoint } from './commands/reverseAtPointCommands';
 import { blameFile } from './commands/blamingCommands';
+import { copySectionValueCommand } from './commands/copySectionValueCommands';
 
 export const magitRepositories: Map<string, MagitRepository> = new Map<string, MagitRepository>();
 export const views: Map<string, DocumentView> = new Map<string, DocumentView>();
@@ -119,6 +120,8 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(commands.registerTextEditorCommand('magit.diff-file', Command.primeFileCommand(diffFile)));
   context.subscriptions.push(commands.registerTextEditorCommand('magit.stage-file', Command.primeFileCommand(stageFile)));
   context.subscriptions.push(commands.registerTextEditorCommand('magit.unstage-file', Command.primeFileCommand(unstageFile)));
+
+  context.subscriptions.push(commands.registerTextEditorCommand('magit.copy-section-value', Command.primeRepoAndView(copySectionValueCommand)));
 
   context.subscriptions.push(commands.registerCommand('magit.dispatch', async () => {
     const editor = window.activeTextEditor;

--- a/src/views/changes/changeHeaderView.ts
+++ b/src/views/changes/changeHeaderView.ts
@@ -4,7 +4,7 @@ import { Status } from '../../typings/git';
 
 export class ChangeHeaderView extends TextView {
 
-  constructor(private change: MagitChange) {
+  constructor(public change: MagitChange) {
     super();
     const statusLabel = mapFileStatusToLabel(this.change.status);
     const mergingStatusLabel = mapFileStatusToMergingLabel(this.change.status);

--- a/src/views/stashes/stashSectionView.ts
+++ b/src/views/stashes/stashSectionView.ts
@@ -21,7 +21,15 @@ export class StashSectionView extends View {
 
 export class StashItemView extends TextView {
 
+  public get section() {
+    return StashItemView.getSection(this.stash); 
+  }
+
+  private static getSection(stash: Stash) {
+    return `stash@{${stash.index}}`;
+  }
+
   constructor(public stash: Stash) {
-    super(`stash@{${stash.index}} ${stash.description}`);
+    super(`${StashItemView.getSection(stash)} ${stash.description}`);
   }
 }


### PR DESCRIPTION
Related to #57

This PR implements the basic copy section value command. Although the current set is not exhaustive, I believe this set facilitated the most common function, and we can support more views as requested in the future.