### PR TITLE
Implement basic copy-buffer-revision

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,11 @@
       },
       {
         "command": "magit.copy-section-value",
-        "title": "Magit Copy Section value"
+        "title": "Magit Copy Section Value"
+      },
+      {
+        "command": "magit.copy-buffer-revision",
+        "title": "Magit Copy Buffer Revision"
       }
     ],
     "menus": {

--- a/src/commands/copyBufferRevisionCommands.ts
+++ b/src/commands/copyBufferRevisionCommands.ts
@@ -1,0 +1,21 @@
+import { env, window } from 'vscode';
+import * as Constants from '../common/constants';
+import { MagitRepository } from '../models/magitRepository';
+import { DocumentView } from '../views/general/documentView';
+import MagitStatusView from '../views/magitStatusView';
+import { CommitDetailView } from '../views/commitDetailView';
+
+export async function copyBufferRevisionCommands(repository: MagitRepository, currentView: DocumentView) {
+
+    let sectionValue: string | undefined;
+    if (currentView instanceof MagitStatusView) {
+        sectionValue = currentView.HEAD?.commit;
+    } else if (currentView instanceof CommitDetailView) {
+        sectionValue = currentView.commit.hash;
+    }
+
+    if (sectionValue) {
+        await env.clipboard.writeText(sectionValue);
+        window.setStatusBarMessage(sectionValue, Constants.StatusMessageDisplayTimeout);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import { reverting } from './commands/revertingCommands';
 import { reverseAtPoint } from './commands/reverseAtPointCommands';
 import { blameFile } from './commands/blamingCommands';
 import { copySectionValueCommand } from './commands/copySectionValueCommands';
+import { copyBufferRevisionCommands } from './commands/copyBufferRevisionCommands';
 
 export const magitRepositories: Map<string, MagitRepository> = new Map<string, MagitRepository>();
 export const views: Map<string, DocumentView> = new Map<string, DocumentView>();
@@ -122,6 +123,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(commands.registerTextEditorCommand('magit.unstage-file', Command.primeFileCommand(unstageFile)));
 
   context.subscriptions.push(commands.registerTextEditorCommand('magit.copy-section-value', Command.primeRepoAndView(copySectionValueCommand)));
+  context.subscriptions.push(commands.registerTextEditorCommand('magit.copy-buffer-revision', Command.primeRepoAndView(copyBufferRevisionCommands)));
 
   context.subscriptions.push(commands.registerCommand('magit.dispatch', async () => {
     const editor = window.activeTextEditor;

--- a/src/views/commitDetailView.ts
+++ b/src/views/commitDetailView.ts
@@ -12,7 +12,7 @@ export class CommitDetailView extends DocumentView {
   isHighlightable = false;
   needsUpdate = false;
 
-  constructor(uri: Uri, private commit: MagitCommit) {
+  constructor(uri: Uri, public commit: MagitCommit) {
     super(uri);
 
     const commitTextView = new TextView(commit.diff);

--- a/src/views/magitStatusView.ts
+++ b/src/views/magitStatusView.ts
@@ -15,10 +15,12 @@ import { MagitRepository } from '../models/magitRepository';
 import { RebasingSectionView } from './rebasing/rebasingSectionView';
 import { CherryPickingSectionView } from './cherryPicking/cherryPickingSectionView';
 import { RevertingSectionView } from './reverting/revertingSectionView';
+import { MagitBranch } from '../models/magitBranch';
 
 export default class MagitStatusView extends DocumentView {
 
   static UriPath: string = 'status.magit';
+  public HEAD?: MagitBranch;
 
   constructor(uri: Uri, magitState: MagitState) {
     super(uri);
@@ -26,7 +28,7 @@ export default class MagitStatusView extends DocumentView {
   }
 
   provideContent(magitState: MagitState) {
-
+    this.HEAD = magitState.HEAD;
     this.subViews = [];
 
     if (magitState.latestGitError) {


### PR DESCRIPTION
Related #57

This PR implements the basic copy-buffer-revision. However two known buffers are not supported (There are probably more, but I haven't tested all of them):
- Diff view
- Stash view

because we are not parsing any commit hash from them. Moreover, if we do parse, we should parse more than just commit hash so those views can provide more information like magit and allow folding.