### PR TITLE
Implement pull rebase option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "out",
     "lib": [
       "es2018",
+      "ES2019.Array",
       "ES2020.String"
     ],
     "sourceMap": true,


### PR DESCRIPTION
Implement the basic --rebase option for pulling. Note: I haven't tested it extensively. It works to an extend but somehow magit doesn't recognize it is in rebase mode if there's conflict.

Related to #77

The adding of `ES2019.Array` is to support `flatMap` function which is included in the vscode version that we are targeting. 
Vscode [v1.42.1 ships node version v12.4.0](https://github.com/microsoft/vscode/blob/1.42.1/cgmanifest.json#L46-L55), which implemented [`flatMap`](https://node.green/#ES2019-features-Array-prototype--flat--flatMap--Array-prototype-flatMap).