### PR TITLE
Add external diff renderer support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/iconv-lite-umd": "^0.7.0",
+        "ansi-sequence-parser": "^1.1.3",
         "date-fns": "^2.16.1",
         "jsonc-parser": "^3.0.0",
         "which": "^3.0.0"
@@ -441,7 +442,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.0.tgz",
       "integrity": "sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.54.0",
         "@typescript-eslint/types": "5.54.0",
@@ -1269,7 +1269,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1303,7 +1302,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1341,6 +1339,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
+      "integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -2367,7 +2371,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.16.0.tgz",
       "integrity": "sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.2.2",
@@ -6650,7 +6653,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6768,7 +6770,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
       "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -6816,7 +6817,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
       "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.0.1",
@@ -6893,7 +6893,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7568,7 +7567,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.0.tgz",
       "integrity": "sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.54.0",
         "@typescript-eslint/types": "5.54.0",
@@ -8148,8 +8146,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.1",
@@ -8172,7 +8169,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8198,6 +8194,11 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
+      "integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -8942,7 +8943,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.16.0.tgz",
       "integrity": "sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.2.2",
@@ -11915,8 +11915,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.1.0",
@@ -12004,7 +12003,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
       "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -12036,8 +12034,7 @@
           "version": "8.8.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
           "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
@@ -12053,7 +12050,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
       "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -473,6 +473,17 @@
           ],
           "default": "",
           "description": "Like `git.path`. Path and filename of the git executable, e.g. C:\\Program Files\\Git\\bin\\git.exe' (Windows). This can also be an array of string values containing multiple paths to look up."
+        },
+        "magit.use-diff-renderer": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable diff rendering using an external command (see magit.diff-renderer-command)."
+        },
+        "magit.diff-renderer-command": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["delta", "--color-only", "--no-gitconfig", "--true-color", "always", "--dark"],
+          "description": "Command to render diffs, as [executable, ...args]. The command receives unified diff on stdin and must emit ANSI-colored output on stdout."
         }
       }
     },
@@ -804,6 +815,7 @@
   },
   "dependencies": {
     "@vscode/iconv-lite-umd": "^0.7.0",
+    "ansi-sequence-parser": "^1.1.3",
     "date-fns": "^2.16.1",
     "jsonc-parser": "^3.0.0",
     "which": "^3.0.0"

--- a/src/commands/diffingCommands.ts
+++ b/src/commands/diffingCommands.ts
@@ -105,9 +105,9 @@ async function showStash({ repository }: MenuState) {
 }
 
 export function stashToMagitChanges(repository: MagitRepository, nameStatusText: string, diff: string): MagitChange[] {
-  const DIFF_PREFIX = 'diff --git';
+  const DIFF_HEADER = /^diff --git /m;
   const filesWithStatus = nameStatusText.split(Constants.LineSplitterRegex).filter(t => t !== '').map(s => s.split('\t'));
-  const diffs = diff.split(DIFF_PREFIX).filter(r => r !== '');
+  const diffs = diff.split(DIFF_HEADER).filter(r => r !== '');
 
   if (filesWithStatus.length !== diffs.length) {
     return [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,7 @@ import { copyBufferRevisionCommands } from './commands/copyBufferRevisionCommand
 import { submodules } from './commands/submodulesCommands';
 import { forgeRefreshInterval } from './forge';
 import { bisecting } from './commands/bisectCommands';
+import { registerDecorationListener } from './utils/diffWiring';
 
 export const magitRepositories: Map<string, MagitRepository> = new Map<string, MagitRepository>();
 export const views: Map<string, DocumentView> = new Map<string, DocumentView>();
@@ -65,7 +66,15 @@ export const processLog: MagitProcessLogEntry[] = [];
 
 export let gitApi: API;
 export let logPath: string;
-export let magitConfig: { displayBufferSameColumn?: boolean, forgeEnabled?: boolean, hiddenStatusSections: Set<string>, quickSwitchEnabled?: boolean, gitPath?: string };
+export let magitConfig: {
+  displayBufferSameColumn?: boolean,
+  forgeEnabled?: boolean,
+  hiddenStatusSections: Set<string>,
+  quickSwitchEnabled?: boolean,
+  gitPath?: string,
+  useDiffRenderer: boolean,
+  diffRendererCommand: string[]
+};
 
 function loadConfig() {
   let workspaceConfig = workspace.getConfiguration('magit');
@@ -75,7 +84,9 @@ function loadConfig() {
     forgeEnabled: workspaceConfig.get('forge-enabled'),
     hiddenStatusSections: readHiddenStatusSections(workspaceConfig.get('hide-status-sections')),
     quickSwitchEnabled: workspaceConfig.get('quick-switch-enabled'),
-    gitPath: workspaceConfig.get('git-path')
+    gitPath: workspaceConfig.get('git-path'),
+    useDiffRenderer: workspaceConfig.get<boolean>('use-diff-renderer') ?? false,
+    diffRendererCommand: workspaceConfig.get<string[]>('diff-renderer-command') ?? [],
   };
 
   let configCodePath: string | undefined = workspaceConfig.get('code-path');
@@ -130,6 +141,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(
     contentProvider,
     providerRegistrations,
+    registerDecorationListener(),
   );
 
   context.subscriptions.push(

--- a/src/test/suite/diffDecorations.test.ts
+++ b/src/test/suite/diffDecorations.test.ts
@@ -1,0 +1,85 @@
+import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import { getDocumentDecorations } from '../../utils/diffDecorations';
+import { HunkView } from '../../views/changes/hunkView';
+import { Section } from '../../views/general/sectionHeader';
+import { Uri } from 'vscode';
+
+const diffHeader = `diff --git a/src/server.ts b/src/server.ts
+index 1a2b3c4..5d6e7f8 100644
+--- a/src/server.ts
++++ b/src/server.ts
+`;
+
+const hunkText = `@@ -10,7 +10,8 @@ import { createLogger } from './logger';
+ const app = express();
+ const logger = createLogger('server');
+
+-function startServer(port: number) {
++async function startServer(port: number): Promise<void> {
++  logger.info(\`Starting server on port \${port}\`);
+   app.listen(port, () => {
+     logger.info('Server started');
+   });`;
+
+let deltaAvailable: boolean | undefined;
+function hasDelta(): boolean {
+  if (deltaAvailable === undefined) {
+    try {
+      execFileSync('delta', ['--version'], { stdio: 'ignore' });
+      deltaAvailable = true;
+    } catch {
+      deltaAvailable = false;
+    }
+  }
+  return deltaAvailable;
+}
+
+suite('Diff Decorations – view-level integration', function () {
+
+  test('extracts decorations in document coordinates from HunkViews', async function () {
+    if (!hasDelta()) { return this.skip(); }
+
+    const uri = Uri.parse('file:///test/src/server.ts');
+    const hunkView = new HunkView(Section.Unstaged, {
+      diff: hunkText,
+      diffHeader,
+      uri,
+    });
+
+    // Simulate the hunk appearing at line 5 in the rendered document
+    const documentStartLine = 5;
+    hunkView.render(documentStartLine);
+
+    const decorations = await getDocumentDecorations([hunkView], ['delta', '--color-only', '--no-gitconfig', '--dark']);
+
+    assert.ok(decorations.length > 0, 'Expected decoration ranges');
+
+    // All decoration lines must be in document coordinate space
+    const hunkLineCount = hunkText.split('\n').length;
+    const documentEndLine = documentStartLine + hunkLineCount - 1;
+    for (const d of decorations) {
+      assert.ok(
+        d.line >= documentStartLine && d.line <= documentEndLine,
+        `Decoration line ${d.line} should be in [${documentStartLine}, ${documentEndLine}]`,
+      );
+    }
+
+    // At least one range should have a foreground color (syntax highlight)
+    const hasColor = decorations.some((d: { foreground?: string }) => d.foreground !== undefined);
+    assert.ok(hasColor, 'Expected at least one decoration with a foreground color');
+  });
+
+  test('returns empty array when renderer is unavailable', async () => {
+    const uri = Uri.parse('file:///test/src/server.ts');
+    const hunkView = new HunkView(Section.Unstaged, {
+      diff: hunkText,
+      diffHeader,
+      uri,
+    });
+    hunkView.render(0);
+
+    const decorations = await getDocumentDecorations([hunkView], ['/nonexistent/delta']);
+    assert.deepStrictEqual(decorations, []);
+  });
+});

--- a/src/test/suite/diffRenderer.test.ts
+++ b/src/test/suite/diffRenderer.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import { renderDiff, DecorationRange } from '../../utils/diffRenderer';
+
+const sampleDiff = `diff --git a/src/server.ts b/src/server.ts
+index 1a2b3c4..5d6e7f8 100644
+--- a/src/server.ts
++++ b/src/server.ts
+@@ -10,7 +10,8 @@ import { createLogger } from './logger';
+ const app = express();
+ const logger = createLogger('server');
+
+-function startServer(port: number) {
++async function startServer(port: number): Promise<void> {
++  logger.info(\`Starting server on port \${port}\`);
+   app.listen(port, () => {
+     logger.info('Server started');
+   });
+`;
+
+let deltaAvailable: boolean | undefined;
+function hasDelta(): boolean {
+  if (deltaAvailable === undefined) {
+    try {
+      execFileSync('delta', ['--version'], { stdio: 'ignore' });
+      deltaAvailable = true;
+    } catch {
+      deltaAvailable = false;
+    }
+  }
+  return deltaAvailable;
+}
+
+suite('Diff Renderer', function () {
+
+  test('produces decoration ranges with syntax colors for a TypeScript diff', async function () {
+    if (!hasDelta()) { return this.skip(); }
+
+    const ranges: DecorationRange[] = await renderDiff(sampleDiff, 'src/server.ts', ['delta', '--color-only', '--no-gitconfig', '--dark']);
+
+    assert.ok(ranges.length > 0, 'Expected at least one decoration range');
+
+    const hasColor = ranges.some(r => r.foreground !== undefined || r.background !== undefined);
+    assert.ok(hasColor, 'Expected at least one range with a foreground or background color');
+  });
+
+  test('preserves diff structure (line count unchanged)', async function () {
+    if (!hasDelta()) { return this.skip(); }
+
+    const ranges: DecorationRange[] = await renderDiff(sampleDiff, 'src/server.ts', ['delta', '--color-only', '--no-gitconfig', '--dark']);
+
+    const maxLine = Math.max(...ranges.map(r => r.line));
+    const inputLines = sampleDiff.split('\n').length - 1; // trailing newline
+    assert.ok(maxLine < inputLines, 'Decoration line numbers must be within diff bounds');
+  });
+
+  test('returns empty array when renderer is not installed', async () => {
+    const ranges = await renderDiff(sampleDiff, 'src/server.ts', ['/nonexistent/delta']);
+    assert.deepStrictEqual(ranges, [], 'Should gracefully return empty array');
+  });
+});

--- a/src/test/suite/diffWiring.test.ts
+++ b/src/test/suite/diffWiring.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import { Uri } from 'vscode';
+import { collectHunkViews, groupDecorationsByStyle } from '../../utils/diffWiring';
+import { getDocumentDecorations } from '../../utils/diffDecorations';
+import { DecorationRange } from '../../utils/diffRenderer';
+import { HunkView } from '../../views/changes/hunkView';
+import { ChangeSectionView } from '../../views/changes/changesSectionView';
+import { ChangeView } from '../../views/changes/changeView';
+import { Section } from '../../views/general/sectionHeader';
+import { MagitChange } from '../../models/magitChange';
+import { Status } from '../../typings/git';
+
+const diffHeader = `diff --git a/src/app.ts b/src/app.ts
+index aaa1111..bbb2222 100644
+--- a/src/app.ts
++++ b/src/app.ts
+`;
+
+const hunkDiff = `@@ -1,5 +1,6 @@
+ import express from 'express';
++import cors from 'cors';
+
+ const app = express();
++app.use(cors());
+ app.listen(3000);`;
+
+function makeChange(path: string): MagitChange {
+  const uri = Uri.parse(`file:///repo/${path}`);
+  return {
+    uri,
+    originalUri: uri,
+    renameUri: undefined,
+    status: Status.MODIFIED,
+    hunks: [{ diff: hunkDiff, diffHeader, uri }],
+  };
+}
+
+let deltaAvailable: boolean | undefined;
+function hasDelta(): boolean {
+  if (deltaAvailable === undefined) {
+    try {
+      execFileSync('delta', ['--version'], { stdio: 'ignore' });
+      deltaAvailable = true;
+    } catch {
+      deltaAvailable = false;
+    }
+  }
+  return deltaAvailable;
+}
+
+suite('Diff Wiring – view tree collection and style grouping', function () {
+
+  test('collectHunkViews finds HunkViews in unfolded ChangeViews', () => {
+    const changes = [makeChange('src/app.ts'), makeChange('src/server.ts')];
+    const section = new ChangeSectionView(Section.Unstaged, changes);
+    for (const sub of section.subViews) {
+      if (sub instanceof ChangeView) {
+        sub.folded = false;
+      }
+    }
+    section.render(0);
+
+    const hunkViews = collectHunkViews(section);
+
+    assert.strictEqual(hunkViews.length, 2, 'Expected one HunkView per change');
+    for (const hv of hunkViews) {
+      assert.ok(hv instanceof HunkView, 'Each element must be a HunkView');
+      assert.ok(
+        hv.range.start.line >= 0,
+        'HunkView range must be set after render',
+      );
+    }
+  });
+
+  test('collectHunkViews excludes HunkViews inside folded ChangeViews', () => {
+    const changes = [makeChange('src/folded1.ts'), makeChange('src/folded2.ts')];
+    const section = new ChangeSectionView(Section.Unstaged, changes);
+    section.render(0);
+
+    const hunkViews = collectHunkViews(section);
+
+    assert.strictEqual(hunkViews.length, 0,
+      'Folded ChangeViews should not yield HunkViews (their ranges do not correspond to document lines)');
+  });
+
+  test('full pipeline: unfolded hunks produce non-empty decoration groups', async function () {
+    if (!hasDelta()) { return this.skip(); }
+
+    const changes = [makeChange('src/pipeline.ts')];
+    const section = new ChangeSectionView(Section.Unstaged, changes);
+    for (const sub of section.subViews) {
+      if (sub instanceof ChangeView) {
+        sub.folded = false;
+      }
+    }
+    section.render(0);
+
+    const hunkViews = collectHunkViews(section);
+    assert.ok(hunkViews.length > 0, 'Should find hunks in unfolded ChangeViews');
+
+    const decorations = await getDocumentDecorations(hunkViews, ['delta', '--color-only', '--no-gitconfig', '--dark']);
+    assert.ok(decorations.length > 0, 'Renderer should produce decoration ranges');
+
+    const groups = groupDecorationsByStyle(decorations);
+    assert.ok(groups.length > 0, 'Should produce at least one style group');
+
+    const totalRanges = groups.reduce((sum: number, g: { ranges: unknown[] }) => sum + g.ranges.length, 0);
+    assert.ok(totalRanges > 0, 'Groups must contain ranges');
+
+    // Decoration lines must fall within the hunk ranges in the document
+    const minLine = Math.min(...hunkViews.map((hv: HunkView) => hv.range.start.line));
+    const maxLine = Math.max(...hunkViews.map((hv: HunkView) => hv.range.end.line));
+    for (const g of groups) {
+      for (const r of g.ranges) {
+        assert.ok(r.line >= minLine && r.line <= maxLine,
+          `Decoration line ${r.line} outside hunk range [${minLine}, ${maxLine}]`);
+      }
+    }
+  });
+
+  test('groupDecorationsByStyle groups by (foreground, background) pair', () => {
+    const decorations: DecorationRange[] = [
+      { line: 5, startChar: 0, endChar: 6, foreground: '#ff0000' },
+      { line: 5, startChar: 7, endChar: 12, foreground: '#00ff00' },
+      { line: 6, startChar: 0, endChar: 4, foreground: '#ff0000' },
+      { line: 7, startChar: 0, endChar: 10, foreground: '#ff0000', background: '#111111' },
+      { line: 8, startChar: 0, endChar: 3 },
+    ];
+
+    const groups = groupDecorationsByStyle(decorations);
+
+    const withColor = decorations.filter(d => d.foreground || d.background);
+    const totalRanges = groups.reduce((sum: number, g: { ranges: unknown[] }) => sum + g.ranges.length, 0);
+    assert.strictEqual(totalRanges, withColor.length, 'Total ranges must equal colored input decorations');
+
+    const redGroup = groups.find((g: { foreground?: string; background?: string }) => g.foreground === '#ff0000' && !g.background);
+    assert.ok(redGroup, 'Expected a group for foreground=#ff0000');
+    assert.strictEqual(redGroup!.ranges.length, 2);
+
+    const redBgGroup = groups.find((g: { foreground?: string; background?: string }) => g.foreground === '#ff0000' && g.background === '#111111');
+    assert.ok(redBgGroup, 'Expected a separate group when background differs');
+    assert.strictEqual(redBgGroup!.ranges.length, 1);
+
+    const greenGroup = groups.find((g: { foreground?: string }) => g.foreground === '#00ff00');
+    assert.ok(greenGroup, 'Expected a group for foreground=#00ff00');
+    assert.strictEqual(greenGroup!.ranges.length, 1);
+  });
+});

--- a/src/test/suite/diffingCommands.test.ts
+++ b/src/test/suite/diffingCommands.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import { Uri } from 'vscode';
+import { stashToMagitChanges } from '../../commands/diffingCommands';
+import { MagitRepository } from '../../models/magitRepository';
+
+const repository = {
+  gitRepository: { rootUri: Uri.parse('file:///repo') },
+} as unknown as MagitRepository;
+
+suite('diffing commands', () => {
+  test('stashToMagitChanges - diff content containing a literal "diff --git" line', () => {
+    const nameStatus = 'A\tsrc/foo.test.ts\nM\tsrc/bar.ts';
+    const diff = `diff --git a/src/foo.test.ts b/src/foo.test.ts
+new file mode 100644
+index 0000000..1a2b3c4
+--- /dev/null
++++ b/src/foo.test.ts
+@@ -0,0 +1,2 @@
++const sample = \`diff --git a/x b/x
++\`;
+diff --git a/src/bar.ts b/src/bar.ts
+index 1a2b3c4..5d6e7f8 100644
+--- a/src/bar.ts
++++ b/src/bar.ts
+@@ -1,1 +1,1 @@
+-old
++new
+`;
+
+    const changes = stashToMagitChanges(repository, nameStatus, diff);
+    assert.strictEqual(changes.length, 2);
+    assert.strictEqual(changes[0].relativePath, 'src/foo.test.ts');
+    assert.strictEqual(changes[1].relativePath, 'src/bar.ts');
+  });
+});

--- a/src/utils/commandRunner/command.ts
+++ b/src/utils/commandRunner/command.ts
@@ -172,6 +172,20 @@ async function exec(child: cp.ChildProcess, cancellationToken?: CancellationToke
   }
 }
 
+let cachedGitPath: string | undefined;
+let cachedGitPathHintsKey: string | undefined;
+
+async function resolveGitPath(pathHints: string[]): Promise<string> {
+  const hintsKey = pathHints.join('\0');
+  if (cachedGitPath && cachedGitPathHintsKey === hintsKey) {
+    return cachedGitPath;
+  }
+  const git = await findGit(pathHints, () => true);
+  cachedGitPath = git.path;
+  cachedGitPathHintsKey = hintsKey;
+  return git.path;
+}
+
 async function _exec(args: string[], options: SpawnOptions = {}): Promise<IExecutionResult<string>> {
 
   let pathHints = Array.isArray(magitConfig.gitPath) ? magitConfig.gitPath : magitConfig.gitPath ? [magitConfig.gitPath] : [];
@@ -179,8 +193,8 @@ async function _exec(args: string[], options: SpawnOptions = {}): Promise<IExecu
     pathHints = pathHints.filter(p => path.isAbsolute(p));
   }
 
-  const git = await findGit(pathHints, () => true);
-  const child = spawn(git.path, [...GitConfigOverrideArgs, ...args], options);
+  const gitPath = await resolveGitPath(pathHints);
+  const child = spawn(gitPath, [...GitConfigOverrideArgs, ...args], options);
 
   // options.onSpawn?.(child);
 

--- a/src/utils/diffDecorations.ts
+++ b/src/utils/diffDecorations.ts
@@ -1,0 +1,59 @@
+import { DecorationRange, renderDiff } from './diffRenderer';
+import { HunkView } from '../views/changes/hunkView';
+
+export async function getDocumentDecorations(
+  hunkViews: HunkView[],
+  command: string[],
+): Promise<DecorationRange[]> {
+  if (hunkViews.length === 0) {
+    return [];
+  }
+
+  const byFile = new Map<string, HunkView[]>();
+  for (const hv of hunkViews) {
+    const key = hv.changeHunk.uri.toString();
+    let group = byFile.get(key);
+    if (!group) {
+      group = [];
+      byFile.set(key, group);
+    }
+    group.push(hv);
+  }
+
+  const results = await Promise.all(
+    [...byFile.values()].map(group => decorationsForFileGroup(group, command)),
+  );
+  return results.flat();
+}
+
+async function decorationsForFileGroup(
+  group: HunkView[],
+  command: string[],
+): Promise<DecorationRange[]> {
+  const { diffHeader, uri } = group[0].changeHunk;
+
+  const headerNormalized = diffHeader.endsWith('\n') ? diffHeader : diffHeader + '\n';
+  const fullDiff = headerNormalized + group.map(hv => hv.changeHunk.diff).join('\n');
+
+  const headerLineCount = headerNormalized.split('\n').length - 1;
+  const mappings: { rendererStart: number; lineCount: number; docStart: number }[] = [];
+  let cursor = headerLineCount;
+  for (const hv of group) {
+    const lineCount = hv.changeHunk.diff.split('\n').length;
+    mappings.push({ rendererStart: cursor, lineCount, docStart: hv.range.start.line });
+    cursor += lineCount;
+  }
+
+  const raw = await renderDiff(fullDiff, uri.fsPath, command);
+
+  const result: DecorationRange[] = [];
+  for (const d of raw) {
+    for (const m of mappings) {
+      if (d.line >= m.rendererStart && d.line < m.rendererStart + m.lineCount) {
+        result.push({ ...d, line: m.docStart + (d.line - m.rendererStart) });
+        break;
+      }
+    }
+  }
+  return result;
+}

--- a/src/utils/diffRenderer.ts
+++ b/src/utils/diffRenderer.ts
@@ -1,0 +1,91 @@
+import { ChildProcess, spawn } from 'child_process';
+import { parseAnsiSequences, createColorPalette, ParseToken } from 'ansi-sequence-parser';
+
+export interface DecorationRange {
+  line: number;
+  startChar: number;
+  endChar: number;
+  foreground?: string;
+  background?: string;
+}
+
+export async function renderDiff(
+  diff: string,
+  filePath: string,
+  command: string[],
+): Promise<DecorationRange[]> {
+  const t0 = performance.now();
+  const stdout = await spawnRenderer(diff, filePath, command);
+  const elapsed = performance.now() - t0;
+  if (stdout === null) {
+    return [];
+  }
+  console.log(`[edamagit] diff renderer spawn: ${elapsed.toFixed(0)}ms`);
+  const tokens = parseAnsiSequences(stdout);
+  return tokensToRanges(tokens);
+}
+
+function spawnRenderer(diff: string, _filePath: string, command: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    let proc: ChildProcess;
+    try {
+      proc = spawn(command[0], command.slice(1), { stdio: ['pipe', 'pipe', 'ignore'] });
+    } catch {
+      resolve(null);
+      return;
+    }
+    const chunks: Buffer[] = [];
+    let spawnError = false;
+    proc.stdout!.on('data', (chunk: Buffer) => chunks.push(chunk));
+    proc.on('error', (err) => {
+      spawnError = true;
+      console.error(`[edamagit] diff renderer error: ${err.message}`);
+      resolve(null);
+    });
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        if (!spawnError) {
+          console.error(`[edamagit] diff renderer exited with code ${code}`);
+        }
+        resolve(null);
+      } else {
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    });
+    const timeout = setTimeout(() => { proc.kill(); resolve(null); }, 5000);
+    proc.on('close', () => clearTimeout(timeout));
+    proc.stdin!.end(diff);
+  });
+}
+
+const palette = createColorPalette();
+
+function tokensToRanges(tokens: ParseToken[]): DecorationRange[] {
+  const ranges: DecorationRange[] = [];
+  let line = 0;
+  let col = 0;
+  for (const token of tokens) {
+    const hasFg = token.foreground !== null;
+    const hasBg = token.background !== null;
+    const segments = token.value.split('\n');
+    for (let i = 0; i < segments.length; i++) {
+      if (i > 0) {
+        line++;
+        col = 0;
+      }
+      const seg = segments[i];
+      if (seg.length > 0 && (hasFg || hasBg)) {
+        const range: DecorationRange = {
+          line,
+          startChar: col,
+          endChar: col + seg.length,
+        };
+        if (hasFg) { range.foreground = palette.value(token.foreground!); }
+        if (hasBg) { range.background = palette.value(token.background!); }
+        ranges.push(range);
+      }
+      col += seg.length;
+    }
+  }
+  return ranges;
+}

--- a/src/utils/diffWiring.ts
+++ b/src/utils/diffWiring.ts
@@ -1,0 +1,132 @@
+import { TextEditor, Range, Position, Disposable, window, Uri, workspace } from 'vscode';
+import { View } from '../views/general/view';
+import { HunkView } from '../views/changes/hunkView';
+import { DecorationRange } from './diffRenderer';
+import { DocumentView } from '../views/general/documentView';
+import { getDocumentDecorations } from './diffDecorations';
+import { magitConfig, views } from '../extension';
+import * as Constants from '../common/constants';
+
+export interface DecorationGroup {
+  foreground?: string;
+  background?: string;
+  ranges: { line: number; startChar: number; endChar: number }[];
+}
+
+const activeDecorations = new Map<string, Disposable[]>();
+const refreshGeneration = new Map<string, number>();
+
+export function collectHunkViews(view: View): HunkView[] {
+  const result: HunkView[] = [];
+  walkVisible(view, result);
+  return result;
+}
+
+function walkVisible(view: View, out: HunkView[]): void {
+  for (const sub of view.subViews) {
+    if (sub instanceof HunkView) {
+      if (!sub.folded) {
+        out.push(sub);
+      }
+    } else if (!sub.folded) {
+      walkVisible(sub, out);
+    }
+  }
+}
+
+export function groupDecorationsByStyle(decorations: DecorationRange[]): DecorationGroup[] {
+  const map = new Map<string, DecorationGroup>();
+  for (const d of decorations) {
+    if (!d.foreground && !d.background) continue;
+    const key = `${d.foreground ?? ''}|${d.background ?? ''}`;
+    let group = map.get(key);
+    if (!group) {
+      group = { foreground: d.foreground, background: d.background, ranges: [] };
+      map.set(key, group);
+    }
+    group.ranges.push({ line: d.line, startChar: d.startChar, endChar: d.endChar });
+  }
+  return [...map.values()];
+}
+
+export async function applyDecorations(
+  editor: TextEditor,
+  view: DocumentView,
+): Promise<Disposable[]> {
+  if (!magitConfig.useDiffRenderer || magitConfig.diffRendererCommand.length === 0) return [];
+
+  const hunkViews = collectHunkViews(view);
+  if (hunkViews.length === 0) return [];
+
+  const decorations = await getDocumentDecorations(hunkViews, magitConfig.diffRendererCommand);
+  if (decorations.length === 0) return [];
+
+  const groups = groupDecorationsByStyle(decorations);
+  const disposables: Disposable[] = [];
+
+  for (const group of groups) {
+    const decorationType = window.createTextEditorDecorationType({
+      color: group.foreground,
+      backgroundColor: withAlpha(group.background, 'bb'),
+    });
+    const ranges = group.ranges.map(
+      r => new Range(new Position(r.line, r.startChar), new Position(r.line, r.endChar)),
+    );
+    editor.setDecorations(decorationType, ranges);
+    disposables.push(decorationType);
+  }
+
+  return disposables;
+}
+
+function withAlpha(color: string | undefined, alpha: string): string | undefined {
+  if (!color) return undefined;
+  if (color.length === 7 && color[0] === '#') return color + alpha;
+  return color;
+}
+
+function disposeForUri(key: string): void {
+  const prev = activeDecorations.get(key);
+  if (prev) {
+    prev.forEach(d => d.dispose());
+    activeDecorations.delete(key);
+  }
+}
+
+export function refreshDecorations(uri: Uri): void {
+  const key = uri.toString();
+  const view = views.get(key);
+  const editor = window.visibleTextEditors.find(
+    ed => ed.document.uri.toString() === key,
+  );
+  if (!view || !editor) {
+    disposeForUri(key);
+    return;
+  }
+
+  disposeForUri(key);
+
+  const gen = (refreshGeneration.get(key) ?? 0) + 1;
+  refreshGeneration.set(key, gen);
+
+  applyDecorations(editor, view).then(
+    disposables => {
+      if (refreshGeneration.get(key) !== gen) {
+        disposables.forEach(d => d.dispose());
+        return;
+      }
+      if (disposables.length > 0) {
+        activeDecorations.set(key, disposables);
+      }
+    },
+    err => console.error('[edamagit] diff decorations failed:', err),
+  );
+}
+
+export function registerDecorationListener(): Disposable {
+  return workspace.onDidChangeTextDocument(e => {
+    if (e.document.uri.scheme === Constants.MagitUriScheme) {
+      refreshDecorations(e.document.uri);
+    }
+  });
+}

--- a/src/utils/viewUtils.ts
+++ b/src/utils/viewUtils.ts
@@ -7,6 +7,7 @@ import { SemanticTokenTypes } from '../common/constants';
 import GitTextUtils from './gitTextUtils';
 import { DocumentView } from '../views/general/documentView';
 import { magitConfig, views } from '../extension';
+import { refreshDecorations } from './diffWiring';
 
 function hasUri(obj: unknown): obj is { uri: Uri } {
   return typeof obj === 'object' && obj !== null && 'uri' in obj && obj.uri instanceof Uri;
@@ -27,7 +28,9 @@ export default class ViewUtils {
   public static async showView(uri: Uri, view: DocumentView, textDocumentShowOptions: TextDocumentShowOptions = { preview: false, preserveFocus: false }) {
     views.set(uri.toString(), view);
     let doc = await workspace.openTextDocument(uri);
-    return window.showTextDocument(doc, { viewColumn: ViewUtils.showDocumentColumn(), ...textDocumentShowOptions });
+    const editor = await window.showTextDocument(doc, { viewColumn: ViewUtils.showDocumentColumn(), ...textDocumentShowOptions });
+    refreshDecorations(uri);
+    return editor;
   }
 
   public static showDocumentColumn(doc?: TextDocument): ViewColumn {


### PR DESCRIPTION
**AI-written PR** *I haven't reviewed this carefully. But I have used it quite a lot. Opening nevertheless, as [discussed](https://github.com/kahole/edamagit/issues/117#issuecomment-5647259066). Please feel free to push fixup / cleanup commits to this branch.*


Makes it possible to use an external tool such as [delta](https://github.com/dandavison/delta) to add colors to diffs displayed by edamagit.


<img width="800" alt="image" src="https://github.com/user-attachments/assets/07f5dd85-d059-4178-bc1a-83105bcd04e1" />



#### Settings:
- `magit.use-diff-renderer`: enable/disable (disabled by default)
- `magit.diff-renderer-command`: full command array (default: an appropriate delta command)


#### Known issue
- I think there's a fairly rare race somehere. Sometimes the colors from the external renderer are not there on first draw; in that situation they appear on folding/unfolding.

#### AI-written commit message

Pipe diffs through a user-configured external command (e.g. delta) to get ANSI-colored output, parse it with ansi-sequence-parser, and apply the results as VS Code text decorations on magit diff views.

New modules:
- `diffRenderer`: spawns the diff renderer subprocess, parses ANSI tokens into `DecorationRange` structs
- `diffDecorations`: reassembles per-file diffs with headers, runs them through the renderer, and maps renderer line numbers back to document positions via hunk view ranges
- `diffWiring`: manages decoration lifecycle (create, dispose, refresh); walks only visible (unfolded) hunk views; uses a generation counter to handle racing `refreshDecorations` calls; registers an `onDidChangeTextDocument` listener to re-apply decorations on fold toggles and status refreshes

